### PR TITLE
feat: EveryInc gaps audit + Cursor Marketplace packaging

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -10,6 +10,7 @@
   "homepage": "https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin",
   "repository": "https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin",
   "license": "MIT",
+  "logo": "assets/logo.svg",
   "keywords": [
     "salesforce",
     "cursor",
@@ -24,5 +25,15 @@
     "workflow-automation",
     "agentforce",
     "knowledge-management"
-  ]
+  ],
+  "category": "developer-tools",
+  "tags": [
+    "salesforce",
+    "compound-engineering",
+    "skills",
+    "workflow",
+    "code-review"
+  ],
+  "skills": "./skills/",
+  "hooks": "./hooks/hooks.json"
 }

--- a/README.md
+++ b/README.md
@@ -46,13 +46,25 @@ Above the loop, **`/sf-strategy`** maintains an optional repo-root `STRATEGY.md`
 /plugin install sf-compound-engineering
 ```
 
+### Cursor
+
+**Local / Git install (current):**
+
+```bash
+bunx @gellasangameshgupta/sf-compound-plugin install sf-compound-engineering --to cursor
+```
+
+Or open this repo in Cursor; the single-plugin manifest is `.cursor-plugin/plugin.json` (skills at repo root, hooks at `hooks/hooks.json`, MCP at `mcp.json`).
+
+**Cursor Marketplace:** packaging is aligned to the [Cursor plugin template](https://github.com/cursor/plugin-template) single-plugin shape. Listing submission is pending (validate with `node scripts/validate-cursor-plugin.mjs`). See the readiness section in [`docs/solutions/integrations/everyinc-v321-vs-sf-v31-gaps.md`](./docs/solutions/integrations/everyinc-v321-vs-sf-v31-gaps.md).
+
 ### Other AI Coding Tools (11 platforms)
 
 ```bash
 # GitHub Copilot
 bunx @gellasangameshgupta/sf-compound-plugin install sf-compound-engineering --to copilot
 
-# Cursor
+# Cursor (also see Cursor section above)
 bunx @gellasangameshgupta/sf-compound-plugin install sf-compound-engineering --to cursor
 
 # Windsurf

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="Salesforce Compound Engineering">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0B5CAB"/>
+      <stop offset="100%" stop-color="#032D60"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="28" fill="url(#g)"/>
+  <path d="M34 78c8 14 28 22 46 14 10-4 18-12 22-22-8 6-18 10-28 10-16 0-30-8-40-2z" fill="#FFFFFF" opacity=".92"/>
+  <path d="M28 56c10-18 34-28 54-18 8 4 14 10 18 18-10-4-22-4-34 2-12 6-24 8-38-2z" fill="#90D0FE"/>
+  <circle cx="86" cy="40" r="10" fill="#FFFFFF"/>
+  <circle cx="86" cy="40" r="5" fill="#00A1E0"/>
+</svg>

--- a/docs/brainstorms/README.md
+++ b/docs/brainstorms/README.md
@@ -1,0 +1,15 @@
+# Brainstorms
+
+Pre-planning exploration records produced by `/sf-brainstorm` (and related ideation work).
+
+## Conventions
+
+- Keep brainstorms as permanent project records.
+- Prefer dated filenames: `YYYY-MM-DD-<slug>.md`.
+- Never delete entries. If obsolete, set `status: deprecated` in frontmatter and leave the file in place.
+
+## Related
+
+- `/sf-brainstorm` — creates brainstorm docs
+- `/sf-plan` — consumes accepted brainstorm outcomes
+- [`CLAUDE.md`](../../CLAUDE.md) — protected-directory policy

--- a/docs/plans/2026-03-02-feat-close-teardown-gaps-plan.md
+++ b/docs/plans/2026-03-02-feat-close-teardown-gaps-plan.md
@@ -2,9 +2,13 @@
 title: Close Teardown Gaps Between SF Plugin and Every's Plugin
 type: feat
 date: 2026-03-02
+status: deprecated
+superseded_by: docs/solutions/integrations/everyinc-v321-vs-sf-v31-gaps.md
 ---
 
 # <span data-proof="authored" data-by="ai:claude">Close Teardown Gaps — SF Plugin vs Every's Compound Engineering Plugin</span>
+
+> **Deprecated (2026-07-31).** This v2-era 31-gap matrix is historical. Current inventory lives in [`docs/solutions/integrations/everyinc-v321-vs-sf-v31-gaps.md`](../solutions/integrations/everyinc-v321-vs-sf-v31-gaps.md) (EveryInc `compound-engineering-v3.21.0` vs SF `3.1.0-beta.5`). Do not use this document as the open-gap backlog.
 
 ## <span data-proof="authored" data-by="ai:claude">Overview</span>
 

--- a/docs/plans/2026-07-31-001-feat-everyinc-gap-sync-and-gaps-doc-plan.md
+++ b/docs/plans/2026-07-31-001-feat-everyinc-gap-sync-and-gaps-doc-plan.md
@@ -1,0 +1,316 @@
+---
+title: Fetch EveryInc updates, sync SF plugin, gaps doc, and Cursor Marketplace readiness
+type: feat
+status: active
+date: 2026-07-31
+---
+
+# feat: EveryInc sync verification + gaps document + Cursor Marketplace readiness
+
+## Overview
+
+Create a repeatable sync-and-compare workflow that:
+
+1. Fetches the latest [EveryInc/compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin) (currently `compound-engineering-v3.21.0`).
+2. Verifies this workspace against the SF Compound Engineering plugin remote(s).
+3. Produces a **fresh gaps document** that supersedes the stale v2-era matrix in [`docs/plans/2026-03-02-feat-close-teardown-gaps-plan.md`](./2026-03-02-feat-close-teardown-gaps-plan.md).
+4. Confirms local files are synced from the SF plugin source of truth.
+5. Brings Cursor packaging to [plugin-template](https://github.com/cursor/plugin-template) / [cursor/plugins](https://github.com/cursor/plugins) parity and prepares Marketplace submission.
+
+This plan is research-and-documentation first for EveryInc gaps. **Phase F** may include packaging edits required for Cursor Marketplace submit readiness (manifests, logo path, MCP filename, validation). Porting upstream skills remains out of scope unless explicitly selected after the gaps document is accepted.
+
+## Problem Statement / Motivation
+
+The March 2026 teardown gap plan is **no longer accurate**:
+
+| Then (2026-03-02 plan) | Now (`/workspace` on `main`) |
+| --- | --- |
+| 4 commands + 23 agents + 7 skills | Skills-first V3.1: **62 skills**, **61 personas**, **0 agents/**, **0 commands/** |
+| No MCP / hooks / docs | `.mcp.json`, `hooks/`, `docs/plans`, multi-platform manifests |
+| Parallel dispatch missing | Persona dispatch via workflow skills |
+| Compounding incomplete | Compound skill exists, but `docs/solutions/` and `docs/brainstorms/` still absent |
+
+Meanwhile upstream EveryInc has moved to **v3.21.0** with native multi-harness packaging, `docs_root`, cross-model patterns, and several skills SF still lacks (or names differently). Without a current gaps document, porting work will re-open closed gaps and miss real ones.
+
+## Repo identity note (important)
+
+Two similarly named remotes exist historically:
+
+| Repo | Role |
+| --- | --- |
+| `gellasangameshgupta/salesforce-compound-engineering-plugin` | **Current V3.1 source of truth** — this workspace’s `origin` |
+| `gellasangameshgupta/sf-compound-engineering-plugin` | Older/v2 lineage (and earlier Claude-plugin-parity experiments) |
+| `sangameshgupta/sf-compound-engineering-plugin` | Public mirror created during earlier work |
+
+**Default for this plan:** treat `salesforce-compound-engineering-plugin` as the SF local sync source (already checked out at `/workspace` @ `1351206`). If the user insists on the older `sf-compound-engineering-plugin` URL, document the mismatch and either rebase or explicitly fork-compare — do not silently mix trees.
+
+## Research Decision
+
+External research **is required** (cross-repo version delta + packaging posture change). Local patterns are strong, but the gap matrix must be grounded in upstream `compound-engineering-v3.21.0` and the current SF `3.1.0-beta.5` tree.
+
+Key upstream references:
+
+- https://github.com/EveryInc/compound-engineering-plugin
+- Release: https://github.com/EveryInc/compound-engineering-plugin/releases/tag/compound-engineering-v3.21.0
+- README philosophy / install: https://github.com/EveryInc/compound-engineering-plugin/blob/main/README.md
+- Native install strategy: https://github.com/EveryInc/compound-engineering-plugin/blob/main/docs/solutions/integrations/native-plugin-install-strategy.md
+
+Institutional note: prior gap work lives in [`docs/plans/2026-03-02-feat-close-teardown-gaps-plan.md`](./2026-03-02-feat-close-teardown-gaps-plan.md) and [`docs/plans/2026-04-25-001-feat-v3-architecture-migration-plan.md`](./2026-04-25-001-feat-v3-architecture-migration-plan.md). Mark those as historical inputs, not current truth.
+
+## SpecFlow Analysis
+
+| Flow | Expected | Risk if skipped |
+| --- | --- | --- |
+| Fetch upstream | Shallow clone/tag pin of EveryInc `compound-engineering-v3.21.0` | Comparing against stale main |
+| Sync SF local | `git fetch/pull` on `salesforce-compound-engineering-plugin` | Gaps doc describes dirty/out-of-date tree |
+| Diff axes | Skills inventory, personas, manifests, docs dirs, CLI posture, scripts | False gaps / missed gaps |
+| Write gaps doc | New markdown under `docs/` with severity + status columns | Continues relying on stale March plan |
+| Cursor Marketplace | Align manifests/assets/MCP/validate to plugin-template + examples | Rejected or incomplete Marketplace listing |
+| Protect dirs | Create empty `docs/solutions/` + `docs/brainstorms/` with README placeholders if missing | Compound loop has nowhere to write |
+
+Edge cases:
+
+- Skill renamed (`ce-code-review` ↔ `sf-review`) must count as **parity**, not a gap.
+- SF-only capabilities (`sf-tend`, `sf-deepen`, Agentforce/MCP domain skills) are **intentional deltas**, not deficits.
+- Upstream native-harness dirs (`.kimi-plugin`, `.agy`, `.devin-plugin`, etc.) may be deferred if SF remains Claude-first — still document as packaging gaps.
+
+## Proposed Solution
+
+### Phase A — Sync SF local (verify / refresh)
+
+1. Confirm remotes and HEAD:
+   - Expected: `origin` → `gellasangameshgupta/salesforce-compound-engineering-plugin`
+   - Expected: clean `main` tracking `origin/main`
+2. `git fetch origin && git pull --ff-only origin main` (or equivalent).
+3. Record fingerprint in the gaps doc: commit SHA, plugin version from `.claude-plugin/plugin.json` (`3.1.0-beta.5` at plan time), skill count, persona count.
+4. If user also wants the older `sf-compound-engineering-plugin` tree: add as a second remote for comparison only; do not overwrite V3.1 workspace.
+
+### Phase B — Fetch EveryInc updates
+
+1. Shallow-fetch upstream into an isolated path (e.g. `/tmp/everyinc-compound-engineering` or `../_upstream/compound-engineering-plugin`).
+2. Check out tag `compound-engineering-v3.21.0` (or newer if released during execution).
+3. Capture fingerprint: tag, commit SHA, skill count, persona/agent-asset count, manifest list.
+4. Do **not** merge upstream into SF. This is compare-only.
+
+### Phase C — Map gaps (axes)
+
+Build a matrix with columns: `Area`, `EveryInc`, `SF`, `Status` (`parity` / `sf_ahead` / `gap` / `intentional_sf`), `Severity`, `Notes`, `Suggested action`.
+
+Primary axes:
+
+1. **Workflow spine** — brainstorm/plan/work/review/compound/lfg (+ SF deepen/polish/strategy/tend).
+2. **Skill inventory** — name-map `ce-*` → `sf-*`; list missing high-value skills (`handoff`, `babysit-pr`, `retune`, `dogfood`, `pov`, `explain`, `sweep`, product-pulse equivalents, etc.).
+3. **Persona / research assets** — count and ownership (`sf-review` vs `ce-code-review`; plan research agents).
+4. **Packaging** — `.claude-plugin` / `.cursor-plugin` / `.codex-plugin` vs upstream’s broader native manifests; Bun CLI as installer vs maintenance tooling; Cursor Marketplace checklist (Phase F).
+5. **Docs compound surface** — `docs/solutions/`, `docs/brainstorms/`, `docs/ideation/`, `docs/skills/` catalog, `docs_root` support.
+6. **Runtime scripts** — skill-local scripts, cross-model / peer-job patterns, release:validate discipline.
+7. **Principles / glossary** — SF `PRINCIPLES.md` vs upstream CONCEPTS/README philosophy.
+8. **Closed historical gaps** — explicitly mark March 2026 CRITICAL items that V3.1 already closed (parallel persona dispatch, MCP, hooks, deepen, etc.).
+
+### Phase D — Write the gaps document
+
+Create a durable artifact (recommended path):
+
+```text
+docs/plans/2026-07-31-002-audit-everyinc-v321-vs-sf-v31-gaps.md
+```
+
+or, if preferred as institutional audit (not a plan):
+
+```text
+docs/solutions/integrations/everyinc-v321-vs-sf-v31-gaps.md
+```
+
+(Requires creating `docs/solutions/` first — aligns with CLAUDE.md protected-dir expectations.)
+
+Document must include:
+
+- Fingerprints for both trees
+- Summary counts table
+- Severity-ranked open gaps
+- Intentional SF deltas (keepers)
+- Closed gaps since March 2026
+- Recommended next port batch (top 5–10 only)
+
+### Phase E — Minimal local hygiene tied to sync
+
+While syncing/verifying, create missing protected directories if absent (empty scaffolds only):
+
+- `docs/solutions/` (+ short README describing purpose + `schema.yaml` link)
+- `docs/brainstorms/` (+ short README)
+
+Do **not** bulk-port upstream skills in this plan.
+
+### Phase F — Cursor Marketplace readiness
+
+Align this repo with Cursor’s official packaging model so it can be submitted to the Cursor Marketplace.
+
+**Canonical references:**
+
+| Source | Role |
+| --- | --- |
+| [cursor/plugin-template](https://github.com/cursor/plugin-template) | Authoring template + submission checklist + `scripts/validate-template.mjs` |
+| [cursor/plugins](https://github.com/cursor/plugins) | Live multi-plugin marketplace examples (`continual-learning`, `cursor-team-kit`, `pstack`, etc.) |
+
+**Repo shape decision (single-plugin):**
+
+The template defaults to **multi-plugin** (`plugins/*` + root `.cursor-plugin/marketplace.json`). For a **single plugin**, Cursor’s guidance is: keep one root `.cursor-plugin/plugin.json` and **do not** require a marketplace.json. This SF repo already matches the single-plugin shape (skills at repo root). Prefer that shape over restructuring into `plugins/sf-compound-engineering/`.
+
+Optional later: if publishing a private multi-plugin marketplace of SF variants, add `.cursor-plugin/marketplace.json` listing `{ "name", "source", "description" }` entries — mirror Claude’s `.claude-plugin/marketplace.json` only if multi-plugin distribution is needed.
+
+**Plan-time audit vs template / examples:**
+
+| Checklist item | SF today (`3.1.0-beta.5`) | Status |
+| --- | --- | --- |
+| Root `.cursor-plugin/plugin.json` with unique kebab-case `name` | Present: `sf-compound-engineering` | parity |
+| `displayName`, `author`, `description`, `keywords`, `license`, `version` | Present | parity |
+| `category` + `tags` (common on `cursor/plugins` examples) | Missing | gap |
+| `logo` + committed `assets/` image | Missing | gap |
+| Path fields: `skills`, `hooks` (examples declare `./skills/`, `./hooks/hooks.json`) | Skills/hooks exist on disk; **not declared** in Cursor `plugin.json` | gap |
+| `agents` / `rules` / `commands` | Intentionally absent (V3.1 agentless) | intentional_sf — do not invent empty dirs |
+| MCP file named `mcp.json` at plugin root | Have `.mcp.json` only (Claude convention) | gap — dual-ship or symlink/copy for Cursor |
+| Skill/rule frontmatter complete | Skills use `name`/`description`/`argument-hint` | verify during F |
+| `node scripts/validate-template.mjs` (or SF equivalent) | Missing | gap |
+| Public repo link ready for Cursor team submit | Repo exists; submission email `kniparko@anysphere.com` / Cursor Slack | process |
+
+**Phase F execution steps:**
+
+1. **Manifest parity** — update `.cursor-plugin/plugin.json` to match example richness without breaking Claude/Codex converters:
+   - Add `category` (likely `developer-tools`), `tags`, `logo`, `skills: "./skills/"`, `hooks: "./hooks/hooks.json"`.
+   - Add `mcpServers` / MCP path only if Cursor’s schema documents it; otherwise rely on root `mcp.json`.
+   - Keep `name` stable (`sf-compound-engineering`) — marketplace uniqueness matter.
+2. **Assets** — add `assets/logo.svg` or `assets/avatar.png` (committed relative path as in examples). Prefer a simple Salesforce/compound mark; no need for multi-resolution set at submit time.
+3. **MCP dual-ship** — ensure Cursor consumers see `mcp.json`:
+   - Preferred: commit `mcp.json` with the same content as `.mcp.json`, or generate both from CLI converter.
+   - Document which file is canonical for maintainers (recommend `.mcp.json` as source; Cursor copy derived).
+4. **Validation** — either vendor/adapt `scripts/validate-template.mjs` from the template for single-plugin layout, or extend Bun CLI lint to enforce Cursor checklist (name kebab-case, logo exists, skills path resolves, hooks path resolves, mcp.json present).
+5. **README / install docs** — add a short “Install from Cursor Marketplace” section once listing is accepted; until then document “local / Git install” and submission status.
+6. **Submission package** — prepare email/Slack packet for Cursor team:
+   - Public GitHub URL
+   - Plugin `name` + one-line description
+   - Confirmation `validate` passes
+   - Contact owner matching `author` in manifest
+7. **Record findings** — append a “Cursor Marketplace readiness” section to the gaps doc (or a sibling `docs/plans/2026-07-31-003-feat-cursor-marketplace-readiness-plan.md` if Phase F grows large). Mark each checklist row `parity` / `gap` / `intentional_sf`.
+
+**Out of scope for Phase F:**
+
+- Publishing *into* Cursor’s official `cursor/plugins` monorepo (that is Cursor-owned).
+- Creating registered Cursor `agents/` just to look like the advanced starter — contradicts V3.1 agentless principle.
+- Renaming skills to drop `sf-` prefix for marketplace aesthetics.
+
+## Technical Considerations
+
+- Keep SF Salesforce domain depth; do not dilute with generic upstream content.
+- Prefer **guidance-style** porting later (matches SF instruction-based culture).
+- Preserve principle priority from [`PRINCIPLES.md`](../../PRINCIPLES.md) when ranking gaps.
+- Converter/CLI changes should follow upstream’s “native install first” posture where feasible, without dropping SF’s existing Bun installer for users who rely on it.
+
+## System-Wide Impact
+
+- **Interaction graph:** Gaps doc informs future `/sf-compound`, `/sf-plan`, and CLI packaging work; does not change runtime until follow-on plans.
+- **Error propagation:** Wrong remote sync could overwrite V3.1 with v2 tree — mitigated by explicit repo identity gate in Phase A.
+- **State lifecycle:** Comparison clones are disposable; only gaps doc + optional empty docs dirs persist.
+- **API surface parity:** Skill name mapping must cover slash commands, natural-language `description` routing, and converter outputs.
+- **Integration test scenarios:**
+  1. Fresh clone of SF remote matches `/workspace` HEAD after sync.
+  2. Upstream tag checkout is reproducible.
+  3. Gaps doc lists every `ce-*` skill with a mapped SF status.
+  4. Historical CRITICAL gaps from March plan are marked closed or still-open with evidence paths.
+  5. `docs/solutions/` and `docs/brainstorms/` exist after hygiene step.
+  6. Cursor `plugin.json` path fields resolve; `mcp.json` or documented dual-ship present; validate script/lint passes.
+
+## Acceptance Criteria
+
+- [ ] SF local tree verified/synced against `salesforce-compound-engineering-plugin` (SHA recorded).
+- [ ] EveryInc `compound-engineering-v3.21.0` (or newer) fetched and fingerprinted.
+- [ ] Fresh gaps document written with severity + status columns and closed-gap section.
+- [ ] Repo identity mismatch (`sf-` vs `salesforce-`) documented in the gaps doc.
+- [ ] `docs/solutions/` and `docs/brainstorms/` exist (scaffold OK).
+- [ ] March 2026 gap plan referenced as historical; not used as current inventory.
+- [ ] Top recommended port batch listed (≤10 items) with rationale.
+- [ ] Cursor Marketplace checklist completed against plugin-template + cursor/plugins examples (gaps documented; packaging fixes applied or explicitly deferred with owner).
+- [ ] `.cursor-plugin/plugin.json` declares skills/hooks (and logo when asset exists); `mcp.json` available for Cursor consumers.
+- [ ] Validation script or CLI lint covers Cursor single-plugin checklist.
+- [ ] Submission notes drafted (repo URL, plugin name, validate status, contact) for Cursor team / `kniparko@anysphere.com`.
+
+## Success Metrics
+
+- One gaps document that an implementer can execute without re-researching upstream.
+- Zero ambiguity about which GitHub repo is the SF source of truth.
+- Closed-gap accuracy: at least the March CRITICAL set reclassified with file evidence.
+
+## Dependencies & Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Mixing v2 `sf-compound-engineering-plugin` with V3.1 tree | Explicit Phase A identity gate |
+| Upstream releases mid-work | Pin tag; note newer tags if present |
+| Over-porting generic skills | Keepers list + intentional_sf status |
+| Gaps doc becomes another stale plan | Date + version fingerprints; optional `status: active` frontmatter |
+
+## Implementation Todos (execution order)
+
+1. Verify/sync SF local from `salesforce-compound-engineering-plugin` and record fingerprint.
+2. Fetch/pin EveryInc `compound-engineering-v3.21.0` into an isolated compare directory.
+3. Generate skill/persona/manifest inventory diffs (`ce-*` ↔ `sf-*`).
+4. Write fresh gaps document with severity, status, closed gaps, and recommended port batch.
+5. Scaffold `docs/solutions/` and `docs/brainstorms/` if missing.
+6. Mark historical March gap plan as superseded (frontmatter note or status) — edit only, do not delete.
+7. Audit `.cursor-plugin/plugin.json` vs cursor/plugin-template + cursor/plugins examples; record Cursor readiness section.
+8. Apply Cursor packaging fixes: logo asset, path fields, `mcp.json` dual-ship, category/tags, validation.
+9. Draft Marketplace submission packet (do not email unless user asks).
+
+## Sources & References
+
+### Upstream
+
+- https://github.com/EveryInc/compound-engineering-plugin
+- https://github.com/EveryInc/compound-engineering-plugin/releases/tag/compound-engineering-v3.21.0
+- https://every.to/guides/compound-engineering
+
+### SF local / remotes
+
+- https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin (workspace origin)
+- https://github.com/gellasangameshgupta/sf-compound-engineering-plugin (legacy naming)
+- Local: `/workspace` @ plan-time HEAD `1351206`, plugin `3.1.0-beta.5`
+
+### Internal plans
+
+- [`docs/plans/2026-03-02-feat-close-teardown-gaps-plan.md`](./2026-03-02-feat-close-teardown-gaps-plan.md) — historical 31-gap matrix (stale)
+- [`docs/plans/2026-04-25-001-feat-v3-architecture-migration-plan.md`](./2026-04-25-001-feat-v3-architecture-migration-plan.md) — V3 migration
+- [`docs/plans/2026-07-03-001-feat-superpowers-discipline-mechanisms-plan.md`](./2026-07-03-001-feat-superpowers-discipline-mechanisms-plan.md) — discipline protocols
+
+### Local conventions
+
+- [`CLAUDE.md`](../../CLAUDE.md) — agentless V3.1, protected docs dirs
+- [`PRINCIPLES.md`](../../PRINCIPLES.md) — numbered principles for gap prioritization
+- [`skills/index.md`](../../skills/index.md) — current skill catalog
+- [`.cursor-plugin/plugin.json`](../../.cursor-plugin/plugin.json) — current Cursor manifest (partial vs examples)
+
+### Cursor Marketplace
+
+- https://github.com/cursor/plugin-template — single vs multi-plugin layout; submission checklist
+- https://github.com/cursor/plugins — official example plugins and root marketplace.json pattern
+- Example manifests: `continual-learning`, `cursor-team-kit`, `create-plugin`, `pstack` (path fields + logo + category/tags)
+- Submit contact per template README: Cursor team Slack or `kniparko@anysphere.com`
+
+## Preliminary gap snapshot (plan-time, to validate during execution)
+
+Likely **open packaging/docs gaps**:
+
+- Broader native harness manifests (Kimi/Grok/Devin/agy/OpenCode/Pi/Cline native dirs)
+- Missing `docs/solutions/` and `docs/brainstorms/` trees
+- CLI marketed as installer vs upstream native-first + converter-as-tooling
+- Missing or incomplete ports: `handoff`, `babysit-pr`, and other ce-only utilities (confirm against inventory)
+- **Cursor Marketplace:** missing `logo`/`assets/`, undeclared `skills`/`hooks` paths, no `mcp.json` (only `.mcp.json`), no `category`/`tags`, no validate script; single-plugin shape is otherwise correct
+
+Likely **parity / SF-ahead**:
+
+- Skills-first agentless architecture
+- Parallel persona review model
+- SF domain depth (governor/apex/flow/lwc/security/Agentforce/MCP)
+- `PRINCIPLES.md`, `sf-deepen`, `sf-tend`, sandwich ideate/polish loop
+
+Likely **closed since March 2026** (validate with paths):
+
+- Parallel review dispatch, MCP, hooks, brainstorm/deepen/worktree/create-agent-skills, multi-platform converters baseline

--- a/docs/plans/2026-07-31-001-feat-everyinc-gap-sync-and-gaps-doc-plan.md
+++ b/docs/plans/2026-07-31-001-feat-everyinc-gap-sync-and-gaps-doc-plan.md
@@ -1,7 +1,7 @@
 ---
 title: Fetch EveryInc updates, sync SF plugin, gaps doc, and Cursor Marketplace readiness
 type: feat
-status: active
+status: completed
 date: 2026-07-31
 ---
 
@@ -221,17 +221,17 @@ Optional later: if publishing a private multi-plugin marketplace of SF variants,
 
 ## Acceptance Criteria
 
-- [ ] SF local tree verified/synced against `salesforce-compound-engineering-plugin` (SHA recorded).
-- [ ] EveryInc `compound-engineering-v3.21.0` (or newer) fetched and fingerprinted.
-- [ ] Fresh gaps document written with severity + status columns and closed-gap section.
-- [ ] Repo identity mismatch (`sf-` vs `salesforce-`) documented in the gaps doc.
-- [ ] `docs/solutions/` and `docs/brainstorms/` exist (scaffold OK).
-- [ ] March 2026 gap plan referenced as historical; not used as current inventory.
-- [ ] Top recommended port batch listed (≤10 items) with rationale.
-- [ ] Cursor Marketplace checklist completed against plugin-template + cursor/plugins examples (gaps documented; packaging fixes applied or explicitly deferred with owner).
-- [ ] `.cursor-plugin/plugin.json` declares skills/hooks (and logo when asset exists); `mcp.json` available for Cursor consumers.
-- [ ] Validation script or CLI lint covers Cursor single-plugin checklist.
-- [ ] Submission notes drafted (repo URL, plugin name, validate status, contact) for Cursor team / `kniparko@anysphere.com`.
+- [x] SF local tree verified/synced against `salesforce-compound-engineering-plugin` (SHA recorded).
+- [x] EveryInc `compound-engineering-v3.21.0` (or newer) fetched and fingerprinted.
+- [x] Fresh gaps document written with severity + status columns and closed-gap section.
+- [x] Repo identity mismatch (`sf-` vs `salesforce-`) documented in the gaps doc.
+- [x] `docs/solutions/` and `docs/brainstorms/` exist (scaffold OK).
+- [x] March 2026 gap plan referenced as historical; not used as current inventory.
+- [x] Top recommended port batch listed (≤10 items) with rationale.
+- [x] Cursor Marketplace checklist completed against plugin-template + cursor/plugins examples (gaps documented; packaging fixes applied or explicitly deferred with owner).
+- [x] `.cursor-plugin/plugin.json` declares skills/hooks (and logo when asset exists); `mcp.json` available for Cursor consumers.
+- [x] Validation script or CLI lint covers Cursor single-plugin checklist.
+- [x] Submission notes drafted (repo URL, plugin name, validate status, contact) for Cursor team / `kniparko@anysphere.com`.
 
 ## Success Metrics
 

--- a/docs/plans/2026-07-31-002-audit-everyinc-v321-vs-sf-v31-gaps.md
+++ b/docs/plans/2026-07-31-002-audit-everyinc-v321-vs-sf-v31-gaps.md
@@ -1,0 +1,14 @@
+---
+title: Audit pointer — EveryInc v3.21 vs SF v3.1 gaps
+type: audit
+status: active
+date: 2026-07-31
+---
+
+# Audit pointer
+
+The durable gaps audit (fingerprints, skill matrix, closed March gaps, Cursor Marketplace readiness, recommended port batch) lives at:
+
+[`docs/solutions/integrations/everyinc-v321-vs-sf-v31-gaps.md`](../solutions/integrations/everyinc-v321-vs-sf-v31-gaps.md)
+
+Produced by executing [`2026-07-31-001-feat-everyinc-gap-sync-and-gaps-doc-plan.md`](./2026-07-31-001-feat-everyinc-gap-sync-and-gaps-doc-plan.md).

--- a/docs/solutions/README.md
+++ b/docs/solutions/README.md
@@ -1,0 +1,19 @@
+# Solutions
+
+Institutional knowledge for Salesforce Compound Engineering — durable learnings captured by `/sf-compound` and searched by research personas (e.g. `sf-learnings-researcher`).
+
+## Conventions
+
+- One markdown file per learning under a category folder.
+- YAML frontmatter must match the repo-root [`schema.yaml`](../../schema.yaml).
+- Never delete entries. If obsolete, set `status: deprecated` in frontmatter and leave the file in place.
+
+## Categories
+
+Use the `category` enum from `schema.yaml` (governor-limit-issues, deployment-issues, test-failures, security-issues, integration-issues, flow-issues, lwc-issues, data-model-issues, best-practices, patterns).
+
+## Related
+
+- `/sf-compound` — writes new solution docs
+- `/sf-plan` / `/sf-work` — research personas read this tree before proposing approaches
+- [`CLAUDE.md`](../../CLAUDE.md) — protected-directory policy

--- a/docs/solutions/integrations/everyinc-v321-vs-sf-v31-gaps.md
+++ b/docs/solutions/integrations/everyinc-v321-vs-sf-v31-gaps.md
@@ -1,0 +1,195 @@
+---
+title: EveryInc v3.21.0 vs SF Compound Engineering v3.1 gaps audit
+type: audit
+status: active
+date: 2026-07-31
+supersedes: docs/plans/2026-03-02-feat-close-teardown-gaps-plan.md
+---
+
+# Audit: EveryInc `compound-engineering-v3.21.0` vs SF `3.1.0-beta.5`
+
+Fresh gap matrix produced while executing [`2026-07-31-001-feat-everyinc-gap-sync-and-gaps-doc-plan.md`](../../plans/2026-07-31-001-feat-everyinc-gap-sync-and-gaps-doc-plan.md). The March 2026 teardown plan is **historical only**.
+
+## Fingerprints
+
+| Tree | Identity | Version | Commit / tag | Skills | Personas |
+| --- | --- | --- | --- | --- | --- |
+| **SF source of truth** | `gellasangameshgupta/salesforce-compound-engineering-plugin` `origin/main` | `3.1.0-beta.5` | `135120693dc1181d2d4cf1672815b8dcc7c38a29` | 62 | 61 |
+| **EveryInc compare pin** | `EveryInc/compound-engineering-plugin` | `3.21.0` | tag `compound-engineering-v3.21.0` @ `c553b957842fbd87f65f90ff5af4f18deb91f56c` | 32 | 27 |
+
+### Repo identity note
+
+| Repo | Role |
+| --- | --- |
+| `gellasangameshgupta/salesforce-compound-engineering-plugin` | **Current V3.1 source of truth** (this workspace `origin`) |
+| `gellasangameshgupta/sf-compound-engineering-plugin` | Older / v2 lineage — do not mix into this tree |
+| `sangameshgupta/sf-compound-engineering-plugin` | Earlier public mirror — not the sync source for this audit |
+
+## Summary counts
+
+| Axis | EveryInc v3.21.0 | SF v3.1.0-beta.5 | Notes |
+| --- | --- | --- | --- |
+| Skills | 32 | 62 | SF denser (domain + workflow) |
+| Persona / research assets | 27 | 61 | SF agentless personas under skills |
+| Native plugin manifests | Many (`.claude-plugin`, `.cursor-plugin`, `.codex-plugin`, `.kimi-plugin`, `.grok-plugin`, `.devin-plugin`, `.agy`, `.agents`, `.opencode`, `.pi`, `.cline`, …) | `.claude-plugin`, `.cursor-plugin`, `.codex-plugin` (+ Bun CLI converters for more) | Packaging gap for native-first dirs |
+| `docs/solutions/` | Present | Scaffolded this change | Was missing at audit start |
+| `docs/brainstorms/` | Present | Scaffolded this change | Was missing at audit start |
+| Hooks | Present (skill/plugin packaging) | `hooks/hooks.json` | Parity for Claude/Cursor hooks surface |
+| MCP | Context7-oriented upstream packaging | `.mcp.json` + Cursor `mcp.json` dual-ship; Context7 + Salesforce DX | SF ahead on Salesforce DX |
+
+## Workflow spine
+
+| Capability | EveryInc | SF | Status |
+| --- | --- | --- | --- |
+| brainstorm | `ce-brainstorm` | `sf-brainstorm` | parity |
+| plan | `ce-plan` | `sf-plan` | parity |
+| work | `ce-work` | `sf-work` | parity |
+| review | `ce-code-review` | `sf-review` | parity |
+| compound | `ce-compound` | `sf-compound` | parity |
+| lfg | `lfg` | `sf-lfg` | parity |
+| ideate | `ce-ideate` | `sf-ideate` | parity |
+| polish | `ce-polish` | `sf-polish` | parity |
+| strategy | `ce-strategy` | `sf-strategy` | parity |
+| deepen | — | `sf-deepen` | intentional_sf / sf_ahead |
+| tend | — | `sf-tend` | intentional_sf / sf_ahead |
+
+## Skill inventory (`ce-*` → `sf-*`)
+
+Status values: `parity` | `gap` | `intentional_sf` | `sf_ahead`
+
+### Mapped parity
+
+| EveryInc | SF | Status | Notes |
+| --- | --- | --- | --- |
+| `ce-brainstorm` | `sf-brainstorm` | parity | |
+| `ce-code-review` | `sf-review` | parity | Name differs; same role |
+| `ce-commit` | `sf-commit` | parity | |
+| `ce-commit-push-pr` | `sf-commit-push-pr` | parity | |
+| `ce-compound` | `sf-compound` | parity | |
+| `ce-compound-refresh` | `sf-compound-refresh` | parity | |
+| `ce-debug` | `sf-debug` | parity | |
+| `ce-doc-review` | `sf-doc-review` | parity | |
+| `ce-ideate` | `sf-ideate` | parity | |
+| `ce-optimize` | `sf-optimize` | parity | |
+| `ce-plan` | `sf-plan` | parity | |
+| `ce-polish` | `sf-polish` | parity | |
+| `ce-product-pulse` | `sf-product-pulse` | parity | |
+| `ce-proof` | `sf-proof` | parity | |
+| `ce-resolve-pr-feedback` | `sf-resolve-pr-feedback` | parity | |
+| `ce-setup` | `sf-setup` | parity | |
+| `ce-simplify-code` | `sf-simplify-code` | parity | |
+| `ce-strategy` | `sf-strategy` | parity | |
+| `ce-work` | `sf-work` | parity | |
+| `ce-worktree` | `git-worktree` | parity | Prefix/name differs |
+| `lfg` | `sf-lfg` | parity | |
+
+### Upstream-only (open gaps — not ports yet)
+
+| EveryInc skill | Severity | Suggested action |
+| --- | --- | --- |
+| `ce-handoff` | high | Port as `sf-handoff` for session continuity across agents/humans |
+| `ce-babysit-pr` | high | Port as `sf-babysit-pr` for CI/PR watch loops |
+| `ce-explain` | medium | Port guidance-style explain skill for Apex/LWC/Flow diffs |
+| `ce-sweep` | medium | Port repo hygiene sweep adapted to SF metadata noise |
+| `ce-retune` | medium | Evaluate vs existing `sf-update` / compound refresh; port if distinct |
+| `ce-dogfood` | low | Optional — dogfood protocol for plugin authors |
+| `ce-pov` | low | Optional product POV skill |
+| `ce-promote` | low | Evaluate release promote vs SF release-notes / CLI |
+| `ce-riffrec-feedback-analysis` | low | Niche; defer unless RiffRec used |
+| `ce-test-browser` | medium | Useful for LWC UI; port carefully (browser automation) |
+| `ce-test-xcode` | low | Not relevant to Salesforce — skip / intentional non-port |
+
+### SF-only keepers (intentional / ahead)
+
+Representative set (not exhaustive): `sf-deepen`, `sf-tend`, `sf-cli`, Agentforce trio, Apex/LWC/Flow/metadata generators, `governor-limits`, `security-guide`, `hosted-mcp-servers`, `mcp-tool-builder`, `dispatching-parallel-personas`, `PRINCIPLES.md`-backed workflow skills, session/tend surfaces.
+
+## Packaging matrix
+
+| Area | EveryInc | SF | Status | Severity | Suggested action |
+| --- | --- | --- | --- | --- | --- |
+| Claude / Cursor / Codex manifests | Yes | Yes | parity | — | Keep converter sync |
+| Extra native harness dirs (Kimi, Grok, Devin, agy, …) | Yes | Via Bun CLI install targets | gap | medium | Document native-first roadmap; optional native dirs later |
+| `docs/solutions` + `docs/brainstorms` | Yes | Scaffolded | parity (new) | — | Start compounding into them |
+| `docs/ideation`, `docs/skills`, `docs/specs` | Yes | Partial / missing | gap | low | Optional catalog ports |
+| CLI posture | Native install + convert tooling | Bun installer primary | gap | medium | Keep installer; market native manifests more clearly |
+| Principles / concepts | `CONCEPTS.md` / README | `PRINCIPLES.md` | sf_ahead / intentional_sf | — | Keep numbered principles |
+
+## Closed since March 2026 (CRITICAL + HIGH from stale plan)
+
+Evidence paths relative to this repo:
+
+| # | March gap | Status now | Evidence |
+| --- | --- | --- | --- |
+| 1 | Parallel agent dispatch | **closed** | `skills/dispatching-parallel-personas/`, workflow skills Task dispatch |
+| 2 | Multi-agent parallel review | **closed** | `skills/sf-review/` + `skills/sf-review/references/personas/` |
+| 3 | Knowledge compounding system | **mostly closed** | `skills/sf-compound/`, `schema.yaml`, `sf-learnings-researcher`; dirs scaffolded `docs/solutions/` |
+| 4 | Formal workflows | **closed** | skills spine: brainstorm → plan → deepen → work → review → compound (+ lfg) |
+| 5 | Brainstorm phase | **closed** | `skills/sf-brainstorm/` |
+| 6 | Hooks | **closed** | `hooks/hooks.json` |
+| 7 | MCP | **closed** | `.mcp.json` (+ Cursor `mcp.json`) |
+| 8 | Git worktree | **closed** | `skills/git-worktree/` |
+| 9 | Learnings researcher | **closed** | `skills/sf-plan/references/personas/sf-learnings-researcher.md` |
+| 10–14 | Research / deepen / skill creation / CLI | **closed** | personas under `sf-plan`/`sf-review`; `sf-deepen`; `create-agent-skills`; `sf-cli` |
+
+Still open from March spirit: populated institutional `docs/solutions/**` content (scaffold only until teams compound).
+
+## Severity-ranked open gaps (actionable)
+
+1. **high** — Port `handoff` and `babysit-pr` skill equivalents.
+2. **high** — Grow real `docs/solutions/` learnings (process + content), not just README.
+3. **medium** — Cursor Marketplace submission (packaging applied this change; external submit remaining).
+4. **medium** — Consider `explain`, `sweep`, `test-browser` ports.
+5. **medium** — Broader native harness manifests vs CLI-only install.
+6. **low** — dogfood / pov / promote / riffrec / xcode (skip xcode).
+
+## Recommended next port batch (≤10)
+
+1. `sf-handoff` ← `ce-handoff`
+2. `sf-babysit-pr` ← `ce-babysit-pr`
+3. `sf-explain` ← `ce-explain` (Salesforce-flavored)
+4. `sf-sweep` ← `ce-sweep` (metadata-aware)
+5. Evaluate `ce-retune` vs `sf-update` / `sf-compound-refresh`
+6. `sf-test-browser` ← `ce-test-browser` (LWC-focused)
+7. Seed 3–5 real `docs/solutions/` entries from recent SF work
+8. Native-manifest spike for one additional harness (e.g. OpenCode/Pi) if CLI friction reported
+9. Optional `ce-dogfood` for plugin maintainers
+10. Skip `ce-test-xcode`
+
+## Cursor Marketplace readiness
+
+Aligned to [cursor/plugin-template](https://github.com/cursor/plugin-template) (single-plugin shape) and [cursor/plugins](https://github.com/cursor/plugins) examples.
+
+| Checklist item | Status after this change |
+| --- | --- |
+| Root `.cursor-plugin/plugin.json` kebab-case name | parity (`sf-compound-engineering`) |
+| displayName / author / description / keywords / license / version | parity |
+| `category` + `tags` | parity |
+| `logo` + `assets/logo.svg` | parity |
+| `skills` + `hooks` path fields | parity |
+| No empty `agents/` / `rules/` / `commands/` | intentional_sf (V3.1 agentless) |
+| Root `mcp.json` for Cursor | parity (dual-ship; `.mcp.json` remains Claude canonical) |
+| Skill frontmatter `name` + `description` | parity (fixed 4 legacy skills) |
+| `node scripts/validate-cursor-plugin.mjs` | parity |
+| External Marketplace listing / email submit | process — draft below; do not send unless requested |
+
+### Submission packet (draft — do not send yet)
+
+- **Repository:** https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin
+- **Plugin name:** `sf-compound-engineering`
+- **Display name:** Salesforce Compound Engineering
+- **One-liner:** Salesforce-focused compound engineering skills for Cursor (plan → work → review → compound) with Apex/LWC/Flow/Agentforce depth.
+- **Validate:** `node scripts/validate-cursor-plugin.mjs` (expect pass)
+- **Contact:** Gella Sangamesh Gupta — https://github.com/gellasangameshgupta
+- **Submit to:** Cursor team Slack or `kniparko@anysphere.com` (per plugin-template README)
+
+### Maintainer note on MCP
+
+- Canonical Claude file: `.mcp.json`
+- Cursor Marketplace / consumers: `mcp.json` (keep content in sync when editing MCP servers)
+
+## Sources
+
+- EveryInc tag: https://github.com/EveryInc/compound-engineering-plugin/releases/tag/compound-engineering-v3.21.0
+- Cursor template: https://github.com/cursor/plugin-template
+- Cursor examples: https://github.com/cursor/plugins
+- Historical: [`docs/plans/2026-03-02-feat-close-teardown-gaps-plan.md`](../../plans/2026-03-02-feat-close-teardown-gaps-plan.md)

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,19 @@
+{
+  "mcpServers": {
+    "context7": {
+      "type": "http",
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "salesforce-dx": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@salesforce/mcp",
+        "--orgs",
+        "DEFAULT_TARGET_ORG",
+        "--toolsets",
+        "all"
+      ]
+    }
+  }
+}

--- a/scripts/validate-cursor-plugin.mjs
+++ b/scripts/validate-cursor-plugin.mjs
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+/**
+ * Cursor Marketplace validator for this single-plugin repo.
+ * Adapted from https://github.com/cursor/plugin-template/blob/main/scripts/validate-template.mjs
+ *
+ * Usage (from repo root):
+ *   node scripts/validate-cursor-plugin.mjs
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const repoRoot = process.cwd();
+const errors = [];
+const warnings = [];
+const pluginNamePattern = /^[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/;
+
+function addError(message) {
+  errors.push(message);
+}
+
+function addWarning(message) {
+  warnings.push(message);
+}
+
+async function pathExists(targetPath) {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJsonFile(filePath, context) {
+  let raw;
+  try {
+    raw = await fs.readFile(filePath, "utf8");
+  } catch {
+    addError(`${context} is missing: ${filePath}`);
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    addError(`${context} contains invalid JSON (${filePath}): ${error.message}`);
+    return null;
+  }
+}
+
+function normalizeNewlines(content) {
+  return content.replace(/\r\n/g, "\n");
+}
+
+function parseFrontmatter(content) {
+  const normalized = normalizeNewlines(content);
+  if (!normalized.startsWith("---\n")) {
+    return null;
+  }
+
+  const closingIndex = normalized.indexOf("\n---\n", 4);
+  if (closingIndex === -1) {
+    return null;
+  }
+
+  const frontmatterBlock = normalized.slice(4, closingIndex);
+  const fields = {};
+
+  for (const line of frontmatterBlock.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+    const separator = line.indexOf(":");
+    if (separator === -1) {
+      continue;
+    }
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+    fields[key] = value;
+  }
+
+  return fields;
+}
+
+function isSafeRelativePath(value) {
+  if (typeof value !== "string" || value.length === 0) {
+    return false;
+  }
+  if (value.startsWith("http://") || value.startsWith("https://")) {
+    return true;
+  }
+  if (path.isAbsolute(value)) {
+    return false;
+  }
+  const normalized = path.posix.normalize(value.replace(/\\/g, "/"));
+  return !normalized.startsWith("../") && normalized !== "..";
+}
+
+function extractPathValues(value) {
+  if (typeof value === "string") {
+    return [value];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => extractPathValues(entry));
+  }
+  if (value && typeof value === "object") {
+    const candidates = [];
+    if (typeof value.path === "string") {
+      candidates.push(value.path);
+    }
+    if (typeof value.file === "string") {
+      candidates.push(value.file);
+    }
+    return candidates;
+  }
+  return [];
+}
+
+async function validateReferencedPath(pluginDir, fieldName, pathValue, pluginName) {
+  if (pathValue.startsWith("http://") || pathValue.startsWith("https://")) {
+    return;
+  }
+  if (!isSafeRelativePath(pathValue)) {
+    addError(
+      `${pluginName}: field "${fieldName}" has invalid path "${pathValue}". Use a relative path without ".." or absolute prefixes.`
+    );
+    return;
+  }
+  const resolved = path.resolve(pluginDir, pathValue);
+  if (!(await pathExists(resolved))) {
+    addError(`${pluginName}: field "${fieldName}" references missing path "${pathValue}".`);
+  }
+}
+
+async function validateSkillFrontmatter(pluginDir, pluginName) {
+  const skillsDir = path.join(pluginDir, "skills");
+  if (!(await pathExists(skillsDir))) {
+    addWarning(`${pluginName}: no skills/ directory found.`);
+    return;
+  }
+
+  const entries = await fs.readdir(skillsDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const skillFile = path.join(skillsDir, entry.name, "SKILL.md");
+    if (!(await pathExists(skillFile))) {
+      continue;
+    }
+    const content = await fs.readFile(skillFile, "utf8");
+    const parsed = parseFrontmatter(content);
+    const relativeFile = path.relative(repoRoot, skillFile);
+    if (!parsed) {
+      addError(`${pluginName}: skill missing YAML frontmatter: ${relativeFile}`);
+      continue;
+    }
+    for (const key of ["name", "description"]) {
+      if (!parsed[key] || parsed[key].length === 0) {
+        addError(`${pluginName}: skill missing "${key}" in frontmatter: ${relativeFile}`);
+      }
+    }
+  }
+}
+
+async function validatePlugin(pluginDir, pluginNameHint) {
+  const manifestPath = path.join(pluginDir, ".cursor-plugin", "plugin.json");
+  const pluginManifest = await readJsonFile(manifestPath, "Cursor plugin manifest");
+  if (!pluginManifest) {
+    return;
+  }
+
+  const pluginName =
+    typeof pluginManifest.name === "string" ? pluginManifest.name : pluginNameHint;
+
+  if (typeof pluginManifest.name !== "string" || !pluginNamePattern.test(pluginManifest.name)) {
+    addError(
+      `${pluginNameHint}: "name" in plugin.json must be lowercase and use only alphanumerics, hyphens, and periods.`
+    );
+  }
+
+  for (const field of ["displayName", "description", "version", "license"]) {
+    if (typeof pluginManifest[field] !== "string" || pluginManifest[field].length === 0) {
+      addError(`${pluginName}: "${field}" is required in plugin.json.`);
+    }
+  }
+
+  if (!pluginManifest.author || typeof pluginManifest.author.name !== "string") {
+    addError(`${pluginName}: "author.name" is required in plugin.json.`);
+  }
+
+  if (!Array.isArray(pluginManifest.keywords) || pluginManifest.keywords.length === 0) {
+    addWarning(`${pluginName}: "keywords" should be a non-empty array.`);
+  }
+
+  const manifestFields = ["logo", "rules", "skills", "agents", "commands", "hooks", "mcpServers"];
+  for (const field of manifestFields) {
+    const values = extractPathValues(pluginManifest[field]);
+    for (const value of values) {
+      await validateReferencedPath(pluginDir, field, value, pluginName);
+    }
+  }
+
+  if (!pluginManifest.logo) {
+    addWarning(`${pluginName}: "logo" is recommended for Marketplace listing.`);
+  }
+
+  if (!pluginManifest.skills) {
+    addWarning(`${pluginName}: "skills" path field is recommended when shipping skills/.`);
+  }
+
+  await validateSkillFrontmatter(pluginDir, pluginName);
+
+  const hooksPath = path.join(pluginDir, "hooks", "hooks.json");
+  if (!(await pathExists(hooksPath))) {
+    addWarning(`${pluginName}: no hooks/hooks.json file found (only needed when using hooks).`);
+  }
+
+  const mcpPath = path.join(pluginDir, "mcp.json");
+  if (!(await pathExists(mcpPath))) {
+    addWarning(`${pluginName}: no mcp.json file found (only needed when using MCP servers).`);
+  } else if (await pathExists(path.join(pluginDir, ".mcp.json"))) {
+    // Maintainers: .mcp.json is canonical for Claude; mcp.json is the Cursor dual-ship copy.
+  }
+}
+
+async function main() {
+  const marketplacePath = path.join(repoRoot, ".cursor-plugin", "marketplace.json");
+  if (await pathExists(marketplacePath)) {
+    addWarning(
+      "Found .cursor-plugin/marketplace.json. This repo is documented as single-plugin; marketplace.json is optional and unused by this validator's primary path."
+    );
+  }
+
+  const rootManifest = path.join(repoRoot, ".cursor-plugin", "plugin.json");
+  if (!(await pathExists(rootManifest))) {
+    addError(`Single-plugin layout requires ${rootManifest}`);
+    summarizeAndExit();
+    return;
+  }
+
+  await validatePlugin(repoRoot, "sf-compound-engineering");
+  summarizeAndExit();
+}
+
+function summarizeAndExit() {
+  if (warnings.length > 0) {
+    console.log("Warnings:");
+    for (const warning of warnings) {
+      console.log(`- ${warning}`);
+    }
+    console.log("");
+  }
+
+  if (errors.length > 0) {
+    console.error("Validation failed:");
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exit(1);
+  }
+
+  console.log("Validation passed.");
+}
+
+await main();

--- a/skills/compound-docs/SKILL.md
+++ b/skills/compound-docs/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: compound-docs
+description: "Guide for writing solution documents that feed the institutional knowledge system under docs/solutions/. Use when compounding learnings, authoring solution YAML frontmatter, or teaching /sf-compound output shape."
+argument-hint: "[optional topic or solution draft]"
+---
+
 # <span data-proof="authored" data-by="ai:claude">Compound Docs Skill</span>
 
 <span data-proof="authored" data-by="ai:claude">Guide for writing solution documents that feed the institutional knowledge system.</span>

--- a/skills/file-todos/SKILL.md
+++ b/skills/file-todos/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: file-todos
+description: "Track project tasks as individual markdown files in todos/ with status, priority, and context. Use when creating file-based todos, updating todo status, or organizing parallel work items."
+argument-hint: "[optional todo description or todos/ path]"
+---
+
 # File-Based Todos Skill
 
 Track project tasks as individual markdown files in the `todos/` directory. Each file is a self-contained task with status, priority, and context.

--- a/skills/git-worktree/SKILL.md
+++ b/skills/git-worktree/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: git-worktree
+description: "Manage isolated git worktrees for parallel Salesforce development and hotfix branches. Use when creating, listing, or removing worktrees without disturbing an in-progress feature branch."
+argument-hint: "[create|list|remove] [branch or path]"
+---
+
 # Git Worktree Skill
 
 Manage isolated development branches using git worktrees for parallel Salesforce development.

--- a/skills/sf-cli/SKILL.md
+++ b/skills/sf-cli/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: sf-cli
+description: "Reference for common Salesforce CLI (sf) commands: deploy, retrieve, test, org auth, and metadata operations. Use when looking up sf CLI syntax during Salesforce development workflows."
+argument-hint: "[optional command topic: deploy|retrieve|test|org]"
+---
+
 # Salesforce CLI Skill
 
 Reference for common `sf` CLI commands used in Salesforce development workflows.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Executes the sync/gaps/Cursor Marketplace plan:

1. Verified SF source of truth `salesforce-compound-engineering-plugin` @ `1351206` (`3.1.0-beta.5`, 62 skills / 61 personas)
2. Compare-only pin of EveryInc `compound-engineering-v3.21.0` @ `c553b95` (32 skills / 27 personas)
3. Fresh gaps audit + March 2026 plan marked deprecated
4. Scaffolded protected `docs/solutions/` and `docs/brainstorms/`
5. Cursor Marketplace packaging aligned to plugin-template / cursor/plugins examples

## Key artifacts

- Gaps audit: `docs/solutions/integrations/everyinc-v321-vs-sf-v31-gaps.md`
- Cursor validate: `node scripts/validate-cursor-plugin.mjs` (passes)
- Dual-ship MCP: `.mcp.json` (Claude canonical) + `mcp.json` (Cursor)
- Manifest: `.cursor-plugin/plugin.json` now has `logo`, `skills`, `hooks`, `category`, `tags`

## Not in this PR

- Porting upstream skills (`handoff`, `babysit-pr`, etc.) — listed as recommended next batch
- Emailing Cursor Marketplace (`kniparko@anysphere.com`) — draft packet only in the gaps doc
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cfcc68d0-6054-4d7d-9c84-8a297326c0dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cfcc68d0-6054-4d7d-9c84-8a297326c0dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

