### PR TITLE
chore: migrate canonical repo to divingsbysangam account

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,12 +2,12 @@
   "name": "sf-compound-engineering-marketplace",
   "owner": {
     "name": "Gella Sangamesh Gupta",
-    "url": "https://github.com/gellasangameshgupta"
+    "url": "https://github.com/divingsbysangam"
   },
   "metadata": {
     "description": "Salesforce-focused compound engineering plugin marketplace for Claude Code, Cursor, and Codex",
     "version": "3.1.0-beta.6",
-    "homepage": "https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin"
+    "homepage": "https://github.com/divingsbysangam/salesforce-compound-engineering-plugin"
   },
   "plugins": [
     {
@@ -17,10 +17,10 @@
       "version": "3.1.0-beta.6",
       "author": {
         "name": "Gella Sangamesh Gupta",
-        "url": "https://github.com/gellasangameshgupta"
+        "url": "https://github.com/divingsbysangam"
       },
-      "homepage": "https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin",
-      "repository": "https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin",
+      "homepage": "https://github.com/divingsbysangam/salesforce-compound-engineering-plugin",
+      "repository": "https://github.com/divingsbysangam/salesforce-compound-engineering-plugin",
       "license": "MIT",
       "tags": [
         "salesforce",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -4,10 +4,10 @@
   "description": "Salesforce-focused compound engineering plugin for Claude Code, Cursor, and Codex. Skills-first V3 architecture with parallel agent dispatch, institutional knowledge compounding, and Apex/LWC/Flow/Integration coverage.",
   "author": {
     "name": "Gella Sangamesh Gupta",
-    "url": "https://github.com/gellasangameshgupta"
+    "url": "https://github.com/divingsbysangam"
   },
-  "homepage": "https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin",
-  "repository": "https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin",
+  "homepage": "https://github.com/divingsbysangam/salesforce-compound-engineering-plugin",
+  "repository": "https://github.com/divingsbysangam/salesforce-compound-engineering-plugin",
   "license": "MIT",
   "keywords": [
     "salesforce",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -4,10 +4,10 @@
   "description": "Salesforce-focused compound engineering plugin for Codex. Skills-first V3 architecture with parallel agent dispatch, institutional knowledge compounding, and Apex/LWC/Flow/Integration coverage.",
   "author": {
     "name": "Gella Sangamesh Gupta",
-    "url": "https://github.com/gellasangameshgupta"
+    "url": "https://github.com/divingsbysangam"
   },
-  "homepage": "https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin",
-  "repository": "https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin",
+  "homepage": "https://github.com/divingsbysangam/salesforce-compound-engineering-plugin",
+  "repository": "https://github.com/divingsbysangam/salesforce-compound-engineering-plugin",
   "license": "MIT",
   "keywords": [
     "salesforce",
@@ -34,7 +34,7 @@
       "Read",
       "Write"
     ],
-    "websiteURL": "https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin",
+    "websiteURL": "https://github.com/divingsbysangam/salesforce-compound-engineering-plugin",
     "defaultPrompt": [
       "/sf-brainstorm a new Apex feature",
       "/sf-plan the LWC implementation",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -5,10 +5,10 @@
   "description": "Salesforce-focused compound engineering plugin for Cursor. Skills-first V3 architecture with parallel agent dispatch, institutional knowledge compounding, and Apex/LWC/Flow/Integration coverage.",
   "author": {
     "name": "Gella Sangamesh Gupta",
-    "url": "https://github.com/gellasangameshgupta"
+    "url": "https://github.com/divingsbysangam"
   },
-  "homepage": "https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin",
-  "repository": "https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin",
+  "homepage": "https://github.com/divingsbysangam/salesforce-compound-engineering-plugin",
+  "repository": "https://github.com/divingsbysangam/salesforce-compound-engineering-plugin",
   "license": "MIT",
   "logo": "assets/logo.png",
   "keywords": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 * Plugin manifests now identify `3.1.0-beta.6`; catalog is **68 skills** + 61 specialist personas.
 * Gaps audit updated: high-priority EveryInc v3.21 skill gaps marked ported; `sf-retune` documented as distinct from `sf-update` / `sf-compound-refresh`.
+* **Repository & package migration** — canonical repo moved to [`divingsbysangam/salesforce-compound-engineering-plugin`](https://github.com/divingsbysangam/salesforce-compound-engineering-plugin); prior `gellasangameshgupta/salesforce-compound-engineering-plugin` repo superseded. CLI/npm package renamed `@gellasangameshgupta/sf-compound-plugin` → `@divingsbysangam/sf-compound-plugin`. `homepage`/`repository`/author URLs updated across all four manifests.
 
 ## \[3.1.0-beta.3] - 2026-06-22
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Above the loop, **`/sf-strategy`** maintains an optional repo-root `STRATEGY.md`
 
 ```bash
 # Add as a Claude Code plugin marketplace
-/plugin marketplace add https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin
+/plugin marketplace add https://github.com/divingsbysangam/salesforce-compound-engineering-plugin
 
 # Install
 /plugin install sf-compound-engineering
@@ -51,7 +51,7 @@ Above the loop, **`/sf-strategy`** maintains an optional repo-root `STRATEGY.md`
 **Install today (CLI / Git):**
 
 ```bash
-bunx @gellasangameshgupta/sf-compound-plugin install sf-compound-engineering --to cursor
+bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to cursor
 ```
 
 Or open this repo in Cursor. Manifest: `.cursor-plugin/plugin.json` (skills at repo root, hooks at `hooks/hooks.json`, MCP at `mcp.json`).
@@ -62,43 +62,43 @@ Or open this repo in Cursor. Manifest: `.cursor-plugin/plugin.json` (skills at r
 
 ```bash
 # GitHub Copilot
-bunx @gellasangameshgupta/sf-compound-plugin install sf-compound-engineering --to copilot
+bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to copilot
 
 # Cursor (also see Cursor section above)
-bunx @gellasangameshgupta/sf-compound-plugin install sf-compound-engineering --to cursor
+bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to cursor
 
 # Windsurf
-bunx @gellasangameshgupta/sf-compound-plugin install sf-compound-engineering --to windsurf
+bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to windsurf
 
 # Gemini CLI
-bunx @gellasangameshgupta/sf-compound-plugin install sf-compound-engineering --to gemini
+bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to gemini
 
 # OpenCode
-bunx @gellasangameshgupta/sf-compound-plugin install sf-compound-engineering --to opencode
+bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to opencode
 
 # Codex
-bunx @gellasangameshgupta/sf-compound-plugin install sf-compound-engineering --to codex
+bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to codex
 
 # Kiro
-bunx @gellasangameshgupta/sf-compound-plugin install sf-compound-engineering --to kiro
+bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to kiro
 
 # Factory Droid
-bunx @gellasangameshgupta/sf-compound-plugin install sf-compound-engineering --to droid
+bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to droid
 
 # Pi
-bunx @gellasangameshgupta/sf-compound-plugin install sf-compound-engineering --to pi
+bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to pi
 
 # OpenClaw
-bunx @gellasangameshgupta/sf-compound-plugin install sf-compound-engineering --to openclaw
+bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to openclaw
 
 # Qwen Code
-bunx @gellasangameshgupta/sf-compound-plugin install sf-compound-engineering --to qwen
+bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to qwen
 
 # Auto-detect and install to all detected tools
-bunx @gellasangameshgupta/sf-compound-plugin install sf-compound-engineering --to all
+bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to all
 
 # Sync from current directory to all detected tools
-bunx @gellasangameshgupta/sf-compound-plugin sync
+bunx @divingsbysangam/sf-compound-plugin sync
 ```
 
 ### What Gets Converted
@@ -301,7 +301,7 @@ salesforce-compound-engineering-plugin/
 ├── PRINCIPLES.md             # Seven governing principles (source of truth)
 ├── CLAUDE.md                 # Project context and protected artifacts
 ├── cli/                      # Multi-tool installer CLI (Bun)
-│   ├── package.json          # @gellasangameshgupta/sf-compound-plugin
+│   ├── package.json          # @divingsbysangam/sf-compound-plugin
 │   ├── src/
 │   │   ├── index.ts          # CLI entry (citty)
 │   │   ├── parser/           # Plugin reader + markdown parser

--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "@gellasangameshgupta/sf-compound-plugin",
+      "name": "@divingsbysangam/sf-compound-plugin",
       "dependencies": {
         "citty": "^0.1.6",
         "gray-matter": "^4.0.3",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@gellasangameshgupta/sf-compound-plugin",
+  "name": "@divingsbysangam/sf-compound-plugin",
   "version": "1.0.0",
   "description": "Multi-tool installer for SF Compound Engineering Plugin — converts Claude Code plugins to Copilot, Windsurf, Gemini, Kiro, OpenCode, Codex",
   "type": "module",
@@ -40,6 +40,6 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin"
+    "url": "https://github.com/divingsbysangam/salesforce-compound-engineering-plugin"
   }
 }

--- a/docs/plans/2026-03-02-feat-close-teardown-gaps-plan.md
+++ b/docs/plans/2026-03-02-feat-close-teardown-gaps-plan.md
@@ -12,7 +12,7 @@ superseded_by: docs/solutions/integrations/everyinc-v321-vs-sf-v31-gaps.md
 
 ## <span data-proof="authored" data-by="ai:claude">Overview</span>
 
-<span data-proof="authored" data-by="ai:claude">The teardown (sections 31-38) identified</span> **<span data-proof="authored" data-by="ai:claude">31 gaps</span>** <span data-proof="authored" data-by="ai:claude">across 3 categories between the</span> [<span data-proof="authored" data-by="ai:claude">original compound-engineering-plugin</span>](https://github.com/EveryInc/compound-engineering-plugin) <span data-proof="authored" data-by="ai:claude">and the</span> [<span data-proof="authored" data-by="ai:claude">SF adaptation</span>](https://github.com/sangameshgupta/sf-compound-engineering-plugin)<span data-proof="authored" data-by="ai:claude">. This plan validates each gap against the current codebase state and provides a prioritized implementation roadmap.</span>
+<span data-proof="authored" data-by="ai:claude">The teardown (sections 31-38) identified</span> **<span data-proof="authored" data-by="ai:claude">31 gaps</span>** <span data-proof="authored" data-by="ai:claude">across 3 categories between the</span> [<span data-proof="authored" data-by="ai:claude">original compound-engineering-plugin</span>](https://github.com/EveryInc/compound-engineering-plugin) <span data-proof="authored" data-by="ai:claude">and the</span> [<span data-proof="authored" data-by="ai:claude">SF adaptation</span>](https://github.com/divingsbysangam/salesforce-compound-engineering-plugin)<span data-proof="authored" data-by="ai:claude">. This plan validates each gap against the current codebase state and provides a prioritized implementation roadmap.</span>
 
 ## <span data-proof="authored" data-by="ai:claude">Current State Verified</span>
 
@@ -434,4 +434,4 @@ sf-compound-engineering-plugin/
 
 * <span data-proof="authored" data-by="ai:claude">Original plugin:</span> [<span data-proof="authored" data-by="ai:claude">https://github.com/EveryInc/compound-engineering-plugin</span>](https://github.com/EveryInc/compound-engineering-plugin)
 
-* <span data-proof="authored" data-by="ai:claude">SF plugin:</span> [<span data-proof="authored" data-by="ai:claude">https://github.com/sangameshgupta/sf-compound-engineering-plugin</span>](https://github.com/sangameshgupta/sf-compound-engineering-plugin)
+* <span data-proof="authored" data-by="ai:claude">SF plugin:</span> [<span data-proof="authored" data-by="ai:claude">https://github.com/divingsbysangam/salesforce-compound-engineering-plugin</span>](https://github.com/divingsbysangam/salesforce-compound-engineering-plugin)

--- a/docs/plans/2026-03-02-feat-multi-tool-cli-installer-plan.md
+++ b/docs/plans/2026-03-02-feat-multi-tool-cli-installer-plan.md
@@ -12,7 +12,7 @@ Build a Bun/TypeScript CLI that converts the SF Compound Engineering Plugin (Cla
 
 Currently, the plugin only works with Claude Code. This CLI will read the plugin's markdown commands, agents, skills, and MCP config, then convert them into each platform's native format — exactly how EveryInc's `@every-env/compound-plugin` works.
 
-**Goal:** `bunx @sangameshgupta/sf-compound-plugin install sf-compound-engineering --to [target]`
+**Goal:** `bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to [target]`
 
 ## Problem Statement
 
@@ -88,7 +88,7 @@ cli/
 **Tasks:**
 
 - [ ] Initialize Bun project: `cli/package.json`, `cli/tsconfig.json`
-  - Package name: `@sangameshgupta/sf-compound-plugin`
+  - Package name: `@divingsbysangam/sf-compound-plugin`
   - Dependencies: `citty`, `js-yaml`, `gray-matter`
 - [ ] `src/parser/types.ts` — Define TypeScript interfaces
   ```typescript
@@ -236,7 +236,7 @@ User request: {{args}}
 
 #### Phase 4: Publish + README
 
-- [ ] Publish to npm as `@sangameshgupta/sf-compound-plugin`
+- [ ] Publish to npm as `@divingsbysangam/sf-compound-plugin`
 - [ ] Add CLI section to main README.md
 - [ ] Add `--scope workspace|global` flag support for Windsurf
 - [ ] Integration tests that verify output files match expected formats
@@ -270,14 +270,14 @@ All names: lowercase, special chars → hyphens, deduplicate with numeric suffix
 
 ### Functional
 
-- [ ] `bunx @sangameshgupta/sf-compound-plugin install sf-compound-engineering --to copilot` writes correct files to `.github/`
-- [ ] `bunx @sangameshgupta/sf-compound-plugin install sf-compound-engineering --to windsurf` writes correct files
-- [ ] `bunx @sangameshgupta/sf-compound-plugin install sf-compound-engineering --to gemini` writes correct TOML commands
-- [ ] `bunx @sangameshgupta/sf-compound-plugin install sf-compound-engineering --to kiro` writes JSON configs + prompt files
-- [ ] `bunx @sangameshgupta/sf-compound-plugin install sf-compound-engineering --to opencode` resolves model aliases
-- [ ] `bunx @sangameshgupta/sf-compound-plugin install sf-compound-engineering --to codex` creates prompt+skill pairs
-- [ ] `bunx @sangameshgupta/sf-compound-plugin install sf-compound-engineering --to all` auto-detects and writes to all found tools
-- [ ] `bunx @sangameshgupta/sf-compound-plugin sync --target [tool]` symlinks skills and merges MCP config
+- [ ] `bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to copilot` writes correct files to `.github/`
+- [ ] `bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to windsurf` writes correct files
+- [ ] `bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to gemini` writes correct TOML commands
+- [ ] `bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to kiro` writes JSON configs + prompt files
+- [ ] `bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to opencode` resolves model aliases
+- [ ] `bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to codex` creates prompt+skill pairs
+- [ ] `bunx @divingsbysangam/sf-compound-plugin install sf-compound-engineering --to all` auto-detects and writes to all found tools
+- [ ] `bunx @divingsbysangam/sf-compound-plugin sync --target [tool]` symlinks skills and merges MCP config
 - [ ] All 7 commands, 33 agents, and 12 skills are converted for each platform
 - [ ] MCP config (Context7) is written in each platform's native format
 - [ ] Existing user config is preserved during merges (user wins on conflict)
@@ -304,7 +304,7 @@ All names: lowercase, special chars → hyphens, deduplicate with numeric suffix
 | TOML generation for Gemini | Use `@iarna/toml` or simple string templating (TOML is simple enough) |
 | Kiro's stdio-only MCP | Context7 uses stdio (npx), so no issue for our plugin |
 | Cursor removed CLI install | Sync-only approach (symlinks + MCP merge) |
-| npm publish scope | Need `@sangameshgupta` org on npm, or use unscoped name |
+| npm publish scope | Need `@divingsbysangam` org on npm, or use unscoped name |
 
 ## Success Metrics
 

--- a/docs/plans/2026-04-25-001-feat-v3-architecture-migration-plan.md
+++ b/docs/plans/2026-04-25-001-feat-v3-architecture-migration-plan.md
@@ -597,7 +597,7 @@ Multi-platform manifest layout:
 - Happy path: Each of the 22 ported skills has a SKILL.md with `name` matching the directory and `description` containing at least 3 Salesforce-flavored trigger phrases.
 - Happy path: `sf-debug` description distinguishes it from existing `sf-bug-reproduction-validator` agent — debug is a workflow, the validator is a sub-step inside it.
 - Edge case: Skills that V3 marks as `ce-` only and don't apply to Salesforce (`ce-test-xcode`, `ce-frontend-design`, `ce-gemini-imagegen`, `ce-test-browser`, `ce-work-beta`, `ce-polish-beta`) are explicitly NOT ported.
-- Edge case: `sf-update`'s upstream URL points at the SF plugin's repo (`sangameshgupta/sf-compound-engineering-plugin`), not EveryInc's.
+- Edge case: `sf-update`'s upstream URL points at the SF plugin's repo (`divingsbysangam/salesforce-compound-engineering-plugin`), not EveryInc's.
 - Edge case: `sf-compound-refresh` respects the protected-artifact rule — never deletes `docs/solutions/` content.
 - Integration: Invoking `/sf-debug` in a Salesforce repo loads the skill and the natural-language trigger "why is this trigger failing" auto-routes to the same skill (validates the description's auto-routing in U10).
 
@@ -881,7 +881,7 @@ Ships as `v3.0.0` final. README, CHANGELOG, manifest validation, and live instal
 - **V3 reference (read-only):** `/Users/gellasangamesh/.claude/plugins/cache/every-marketplace/compound-engineering/3.0.6/`
 - **V3 release notes:** `/Users/gellasangamesh/.claude/plugins/cache/every-marketplace/compound-engineering/3.0.6/CHANGELOG.md`
 - **EveryInc plugin GitHub:** `https://github.com/EveryInc/compound-engineering-plugin`
-- **SF plugin GitHub:** `https://github.com/sangameshgupta/sf-compound-engineering-plugin`
+- **SF plugin GitHub:** `https://github.com/divingsbysangam/salesforce-compound-engineering-plugin`
 - **Project memory:** `MEMORY.md` notes on hosted MCP gotchas (preserved verbatim)
 - **Schema validator:** `schema.yaml` (unchanged by this migration)
 - **Project conventions:** `CLAUDE.md` (rewritten in U5)

--- a/docs/plans/2026-07-31-001-feat-everyinc-gap-sync-and-gaps-doc-plan.md
+++ b/docs/plans/2026-07-31-001-feat-everyinc-gap-sync-and-gaps-doc-plan.md
@@ -38,9 +38,9 @@ Two similarly named remotes exist historically:
 
 | Repo | Role |
 | --- | --- |
-| `gellasangameshgupta/salesforce-compound-engineering-plugin` | **Current V3.1 source of truth** — this workspace’s `origin` |
-| `gellasangameshgupta/sf-compound-engineering-plugin` | Older/v2 lineage (and earlier Claude-plugin-parity experiments) |
-| `sangameshgupta/sf-compound-engineering-plugin` | Public mirror created during earlier work |
+| `divingsbysangam/salesforce-compound-engineering-plugin` | **Current V3.1 source of truth** — this workspace’s `origin` |
+| `gelladivingsbysangam/salesforce-compound-engineering-plugin` | Older/v2 lineage (and earlier Claude-plugin-parity experiments) |
+| `divingsbysangam/salesforce-compound-engineering-plugin` | Public mirror created during earlier work |
 
 **Default for this plan:** treat `salesforce-compound-engineering-plugin` as the SF local sync source (already checked out at `/workspace` @ `1351206`). If the user insists on the older `sf-compound-engineering-plugin` URL, document the mismatch and either rebase or explicitly fork-compare — do not silently mix trees.
 
@@ -79,7 +79,7 @@ Edge cases:
 ### Phase A — Sync SF local (verify / refresh)
 
 1. Confirm remotes and HEAD:
-   - Expected: `origin` → `gellasangameshgupta/salesforce-compound-engineering-plugin`
+   - Expected: `origin` → `divingsbysangam/salesforce-compound-engineering-plugin`
    - Expected: clean `main` tracking `origin/main`
 2. `git fetch origin && git pull --ff-only origin main` (or equivalent).
 3. Record fingerprint in the gaps doc: commit SHA, plugin version from `.claude-plugin/plugin.json` (`3.1.0-beta.5` at plan time), skill count, persona count.
@@ -270,8 +270,8 @@ Optional later: if publishing a private multi-plugin marketplace of SF variants,
 
 ### SF local / remotes
 
-- https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin (workspace origin)
-- https://github.com/gellasangameshgupta/sf-compound-engineering-plugin (legacy naming)
+- https://github.com/divingsbysangam/salesforce-compound-engineering-plugin (workspace origin)
+- https://github.com/divingsbysangam/sf-compound-engineering-plugin (legacy naming)
 - Local: `/workspace` @ plan-time HEAD `1351206`, plugin `3.1.0-beta.5`
 
 ### Internal plans

--- a/docs/solutions/integrations/cursor-marketplace-submission.md
+++ b/docs/solutions/integrations/cursor-marketplace-submission.md
@@ -17,13 +17,13 @@ This is a **one-time listing action** (plus occasional re-submit notes if Cursor
 
 | Field | Value |
 | --- | --- |
-| **Logotype URL** | `https://raw.githubusercontent.com/gellasangameshgupta/salesforce-compound-engineering-plugin/main/assets/logo.png` |
+| **Logotype URL** | `https://raw.githubusercontent.com/divingsbysangam/salesforce-compound-engineering-plugin/main/assets/logo.png` |
 | **Description** | Salesforce-focused compound engineering for Cursor: skills for ideate → brainstorm → plan → deepen → work → review → polish → compound, with Apex, LWC, Flow, governor limits, security, and Agentforce depth. |
-| **GitHub repository** | `https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin` |
+| **GitHub repository** | `https://github.com/divingsbysangam/salesforce-compound-engineering-plugin` |
 
 Alternate logotype (SVG, same 1:1 plate):
 
-`https://raw.githubusercontent.com/gellasangameshgupta/salesforce-compound-engineering-plugin/main/assets/logo.svg`
+`https://raw.githubusercontent.com/divingsbysangam/salesforce-compound-engineering-plugin/main/assets/logo.svg`
 
 Logo assets in-repo: `assets/logo.png` (512×512 RGB, solid background plate) and `assets/logo.svg`. Manifest `.cursor-plugin/plugin.json` → `"logo": "assets/logo.png"`.
 
@@ -51,7 +51,7 @@ Run from repo root on the commit you will submit:
 ```bash
 node scripts/validate-cursor-plugin.mjs
 git rev-parse HEAD
-git ls-remote https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin.git HEAD
+git ls-remote https://github.com/divingsbysangam/salesforce-compound-engineering-plugin.git HEAD
 ```
 
 Confirm:
@@ -78,8 +78,8 @@ I'd like to submit a plugin for the Cursor Marketplace.
 Plugin name: sf-compound-engineering
 Display name: Salesforce Compound Engineering
 Version: 3.1.0-beta.6
-Repository: https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin
-Homepage: https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin
+Repository: https://github.com/divingsbysangam/salesforce-compound-engineering-plugin
+Homepage: https://github.com/divingsbysangam/salesforce-compound-engineering-plugin
 License: MIT
 Category: developer-tools
 
@@ -87,7 +87,7 @@ One-liner:
 Salesforce-focused compound engineering skills for Cursor (plan → work → review → compound) with Apex, LWC, Flow, and Agentforce depth.
 
 Author:
-Gella Sangamesh Gupta — https://github.com/gellasangameshgupta
+Gella Sangamesh Gupta — https://github.com/divingsbysangam
 
 Logo: `assets/logo.png`
 Hooks/MCP: `hooks/hooks.json`, root `mcp.json`

--- a/docs/solutions/integrations/everyinc-v321-vs-sf-v31-gaps.md
+++ b/docs/solutions/integrations/everyinc-v321-vs-sf-v31-gaps.md
@@ -14,7 +14,7 @@ Fresh gap matrix produced while executing [`2026-07-31-001-feat-everyinc-gap-syn
 
 | Tree | Identity | Version | Commit / tag | Skills | Personas |
 | --- | --- | --- | --- | --- | --- |
-| **SF (post-port)** | `gellasangameshgupta/salesforce-compound-engineering-plugin` | `3.1.0-beta.6` | this change | 68 | 61 |
+| **SF (post-port)** | `divingsbysangam/salesforce-compound-engineering-plugin` | `3.1.0-beta.6` | this change | 68 | 61 |
 | **SF audit baseline** | `origin/main` at audit time | `3.1.0-beta.5` | `135120693dc1181d2d4cf1672815b8dcc7c38a29` | 62 | 61 |
 | **EveryInc compare pin** | `EveryInc/compound-engineering-plugin` | `3.21.0` | tag `compound-engineering-v3.21.0` @ `c553b957842fbd87f65f90ff5af4f18deb91f56c` | 32 | 27 |
 
@@ -22,9 +22,9 @@ Fresh gap matrix produced while executing [`2026-07-31-001-feat-everyinc-gap-syn
 
 | Repo | Role |
 | --- | --- |
-| `gellasangameshgupta/salesforce-compound-engineering-plugin` | **Current V3.1 source of truth** (this workspace `origin`) |
-| `gellasangameshgupta/sf-compound-engineering-plugin` | Older / v2 lineage — do not mix into this tree |
-| `sangameshgupta/sf-compound-engineering-plugin` | Earlier public mirror — not the sync source for this audit |
+| `divingsbysangam/salesforce-compound-engineering-plugin` | **Current V3.1 source of truth** (this workspace `origin`) |
+| `gelladivingsbysangam/salesforce-compound-engineering-plugin` | Older / v2 lineage — do not mix into this tree |
+| `divingsbysangam/salesforce-compound-engineering-plugin` | Earlier public mirror — not the sync source for this audit |
 
 ## Summary counts
 
@@ -187,11 +187,11 @@ Full maintainer runbook + email body: [`cursor-marketplace-submission.md`](./cur
 
 Quick facts:
 
-- **Repository:** https://github.com/gellasangameshgupta/salesforce-compound-engineering-plugin
+- **Repository:** https://github.com/divingsbysangam/salesforce-compound-engineering-plugin
 - **Plugin name:** `sf-compound-engineering`
 - **Display name:** Salesforce Compound Engineering
 - **Validate:** `node scripts/validate-cursor-plugin.mjs` (CI enforces on PR/main)
-- **Contact:** Gella Sangamesh Gupta — https://github.com/gellasangameshgupta
+- **Contact:** Gella Sangamesh Gupta — https://github.com/divingsbysangam
 - **Submit to:** Cursor team Slack or `kniparko@anysphere.com` (per plugin-template README)
 
 ### Maintainer note on MCP

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,8 @@ dependencies = [
 sfce = "sfce:main"
 
 [project.urls]
-Homepage = "https://github.com/gellasangameshgupta/sf-compound-engineering-plugin"
-Repository = "https://github.com/gellasangameshgupta/sf-compound-engineering-plugin"
+Homepage = "https://github.com/divingsbysangam/sf-compound-engineering-plugin"
+Repository = "https://github.com/divingsbysangam/sf-compound-engineering-plugin"
 
 [tool.hatch.build.targets.wheel]
 packages = ["."]

--- a/skills/sf-update/SKILL.md
+++ b/skills/sf-update/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[no arguments]"
 
 # sf-update
 
-Check the GitHub releases endpoint for sangameshgupta/sf-compound-engineering-plugin against the locally installed version, present the changelog delta, and optionally run `claude /plugin update sf-compound-engineering`.
+Check the GitHub releases endpoint for divingsbysangam/salesforce-compound-engineering-plugin against the locally installed version, present the changelog delta, and optionally run `claude /plugin update sf-compound-engineering`.
 
 \<feature\_description>
 \#$ARGUMENTS
@@ -14,7 +14,7 @@ Check the GitHub releases endpoint for sangameshgupta/sf-compound-engineering-pl
 
 ## Salesforce Angle
 
-* Upstream URL is `https://github.com/sangameshgupta/sf-compound-engineering-plugin`. The skill checks the GitHub releases endpoint for the latest tag and compares against the installed version.
+* Upstream URL is `https://github.com/divingsbysangam/salesforce-compound-engineering-plugin`. The skill checks the GitHub releases endpoint for the latest tag and compares against the installed version.
 
 * Local plugin install lives at the marketplace cache path; reference `.claude-plugin/plugin.json#version` for the installed version.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates the canonical repository and npm package references from `gellasangameshgupta` to the connected `divingsbysangam` GitHub account.

## Changes

- Updated `homepage`, `repository`, and `author` URLs across all four plugin manifests (`.claude-plugin`, `.cursor-plugin`, `.codex-plugin`, marketplace)
- Renamed npm package scope: `@gellasangameshgupta/sf-compound-plugin` → `@divingsbysangam/sf-compound-plugin`
- Updated README install instructions, `pyproject.toml`, `sf-update` skill, integration docs, and gaps audit references
- Added unreleased CHANGELOG entry documenting the migration

## Remaining step (manual)

The connected GitHub token does not have permission to create repositories. To complete the move:

1. Create an empty public repo at https://github.com/new named `salesforce-compound-engineering-plugin` on the `divingsbysangam` account (do **not** initialize with README)
2. Push all branches and tags:
   ```bash
   git remote add divingsbysangam https://github.com/divingsbysangam/salesforce-compound-engineering-plugin.git
   git push divingsbysangam --all
   git push divingsbysangam --tags
   git remote set-url origin https://github.com/divingsbysangam/salesforce-compound-engineering-plugin.git
   ```
3. Delete `gellasangameshgupta/salesforce-compound-engineering-plugin` when ready
4. Reconnect Cursor Cloud Agents to the new repository URL
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1d161dc-499d-47aa-8e10-d07e7ed0abdb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1d161dc-499d-47aa-8e10-d07e7ed0abdb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

