### PR TITLE
release(cli): 1.0.1 — ship the destination-reporting fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+* **CLI `1.0.1`.** `@divings/sf-compound-plugin@1.0.0` was published before the destination-reporting fix landed, so the released binary still warned only about Windsurf and let OpenClaw and Qwen report a project directory they never wrote to. 1.0.1 ships `installRoot()`. A test now pins the version literal in `src/index.ts` to `package.json` so a published binary cannot report a version it is not.
+
 * **Installation paths (DIV-58).** `install` now writes into the directory you run it from instead of back into the plugin, via a new `--output <dir>` flag. Passing a plugin *name* downloads the plugin from GitHub into `$XDG_CACHE_HOME/sfce/plugins` rather than resolving against the working directory, so the advertised one-line install works from any project. Tool auto-detection (`--to all`) now inspects the output directory.
 * **npm publish readiness.** `prepublishOnly` build, `publishConfig.access: public`, `engines`, repository `directory`, and a package README added to `cli/package.json` so the first publish succeeds.
 * **Package renamed to `@divings/sf-compound-plugin`.** The previously advertised `@divingsbysangam` scope does not exist on npm — scopes must match an npm username or an org you own — so publishing it returned `404 Scope not found`. The package now ships under the `@divings` org.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@divings/sf-compound-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Multi-tool installer for SF Compound Engineering Plugin — converts Claude Code plugins to Copilot, Windsurf, Gemini, Kiro, OpenCode, Codex",
   "type": "module",
   "bin": {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -204,7 +204,8 @@ const lint = defineCommand({
 const main = defineCommand({
   meta: {
     name: "sf-compound-plugin",
-    version: "1.0.0",
+    // Kept in step with package.json by tests/version.test.ts.
+    version: "1.0.1",
     description: "Multi-tool installer for SF Compound Engineering Plugin",
   },
   subCommands: {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -5,6 +5,7 @@ import { readPlugin } from "./parser/plugin.js";
 import { lint as lintPlugin } from "./lint/index.js";
 import { detectInstalledTools, isValidTarget } from "./utils/detect.js";
 import { resolvePluginSource } from "./utils/source.js";
+import { CLI_VERSION } from "./version.js";
 import { CopilotConverter } from "./converters/copilot.js";
 import { WindsurfConverter } from "./converters/windsurf.js";
 import { GeminiConverter } from "./converters/gemini.js";
@@ -204,8 +205,7 @@ const lint = defineCommand({
 const main = defineCommand({
   meta: {
     name: "sf-compound-plugin",
-    // Kept in step with package.json by tests/version.test.ts.
-    version: "1.0.1",
+    version: CLI_VERSION,
     description: "Multi-tool installer for SF Compound Engineering Plugin",
   },
   subCommands: {

--- a/cli/src/version.ts
+++ b/cli/src/version.ts
@@ -1,0 +1,8 @@
+/**
+ * Version reported by `sf-compound-plugin --version`.
+ *
+ * This is a literal rather than an import of package.json because tsconfig's
+ * `rootDir: "src"` keeps package.json outside the compilation. `tests/version.test.ts`
+ * compares this constant against package.json so the two cannot drift.
+ */
+export const CLI_VERSION = "1.0.1";

--- a/cli/tests/version.test.ts
+++ b/cli/tests/version.test.ts
@@ -1,17 +1,20 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "fs";
 import { join } from "path";
+import { CLI_VERSION } from "../src/version.js";
 
-// The CLI's `--version` output is a literal in src/index.ts because tsconfig's
-// rootDir keeps package.json out of the compilation. This test is what stops the
-// two from drifting: a published binary reporting a version it is not.
+// `--version` reports CLI_VERSION, which is a literal because tsconfig's rootDir
+// keeps package.json out of the compilation. This test is what stops the two from
+// drifting: a published binary reporting a version it is not.
+//
+// It imports the exported constant rather than pattern-matching the source, so it
+// cannot be fooled by an unrelated `version:` field appearing elsewhere in the file.
 describe("CLI version", () => {
-  test("matches package.json", () => {
-    const root = join(import.meta.dir, "..");
-    const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf-8")) as { version: string };
-    const source = readFileSync(join(root, "src", "index.ts"), "utf-8");
+  test("CLI_VERSION matches package.json", () => {
+    const pkg = JSON.parse(
+      readFileSync(join(import.meta.dir, "..", "package.json"), "utf-8"),
+    ) as { version: string };
 
-    const declared = source.match(/version:\s*"([^"]+)"/)?.[1];
-    expect(declared).toBe(pkg.version);
+    expect(CLI_VERSION).toBe(pkg.version);
   });
 });

--- a/cli/tests/version.test.ts
+++ b/cli/tests/version.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// The CLI's `--version` output is a literal in src/index.ts because tsconfig's
+// rootDir keeps package.json out of the compilation. This test is what stops the
+// two from drifting: a published binary reporting a version it is not.
+describe("CLI version", () => {
+  test("matches package.json", () => {
+    const root = join(import.meta.dir, "..");
+    const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf-8")) as { version: string };
+    const source = readFileSync(join(root, "src", "index.ts"), "utf-8");
+
+    const declared = source.match(/version:\s*"([^"]+)"/)?.[1];
+    expect(declared).toBe(pkg.version);
+  });
+});

--- a/docs/install-verification.md
+++ b/docs/install-verification.md
@@ -173,6 +173,7 @@ install until `install` is re-run. Consider a `--copy` flag if this bites.
 
 ## Still outstanding
 
+- **Republish after every CLI change.** `1.0.0` was published mid-review and did not contain the destination-reporting fix, so for a window the registry served a binary that misreported where OpenClaw and Qwen install. Verify with `npm view @divings/sf-compound-plugin version` against `cli/package.json` before trusting a matrix row.
 - **Five converters are unverified in a clean environment**: OpenCode, Kiro, Pi, OpenClaw and Qwen. They have unit tests but no install run. Windsurf, Gemini and Droid were exercised through `--to all` in Round 1.
 - **Claude Code has had no fresh-user install run.** Manifests are valid and reachable; the install itself is unconfirmed, because `/plugin` cannot be driven from a shell.
 - **Tool-load is unconfirmed everywhere.** Every verified row proves files land in the right place, not that the tool reads them.


### PR DESCRIPTION
Follow-up to #9 (DIV-58).

## The merged fix never reached users

`@divings/sf-compound-plugin@1.0.0` was published **mid-review**, before `installRoot()` landed. Merging #9 fixed the repository; it did not fix what npm serves.

Verified against the published tarball:

```
$ npm pack @divings/sf-compound-plugin@1.0.0 && tar xzf *.tgz
$ grep -c "installRoot" package/dist/index.js
0                                    ← review fix absent
$ grep -c "at global scope, into" package/dist/index.js
1                                    ← superseded Windsurf-only note still present
```

So anyone running `bunx @divings/sf-compound-plugin install … --to openclaw` today still gets a binary that reports the project directory while writing to `~/.openclaw` — the exact defect the #9 review caught.

## Changes

- **CLI `1.0.0` → `1.0.1`**, shipping `installRoot()` and the per-target destination reporting.
- **A test pins the version literal** in `src/index.ts` to `package.json`. That literal exists because tsconfig's `rootDir: "src"` keeps `package.json` out of the compilation, which makes silent drift easy — and a published binary reporting a version it is not is its own small trust problem.
- **`docs/install-verification.md`** gains a standing reminder to check `npm view … version` against `cli/package.json` before trusting a matrix row, since this is the second time the registry and the repo have disagreed.

Gates: typecheck clean · **79 tests pass / 0 fail** (1 new) · plugin lint and Cursor validator pass.

## After merge

`cd cli && npm publish` — `prepublishOnly` rebuilds the bundle. The install matrix rows in the README stay accurate either way, since they describe behaviour that 1.0.1 restores rather than changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHcB3XDZjZaTtFFMWqzeMJ




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prepares CLI version 1.0.1 so the previously merged destination-reporting fix can reach npm users.
- Bumps the package version and sources CLI version reporting from a dedicated exported constant.
- Replaces the vulnerable source-regex check with a direct comparison between the exported constant and `package.json`.
- Documents the release and adds registry-versus-repository verification guidance.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| cli/package.json | Bumps the publishable package version from 1.0.0 to 1.0.1. |
| cli/src/index.ts | Uses the shared `CLI_VERSION` constant for the CLI metadata consumed by version reporting. |
| cli/src/version.ts | Defines the release version in an importable source module. |
| cli/tests/version.test.ts | Directly compares the exported CLI version with package metadata, fully addressing the prior unanchored-regex finding. |
| docs/install-verification.md | Adds a release-verification reminder to compare the npm registry version with repository metadata. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(cli): pin the version through an ex..."](https://github.com/divingsbysangam/salesforce-compound-engineering-plugin/commit/a3fbbd822a129777306f0c9407bd6c48f66979f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55547007)</sub>

<!-- /greptile_comment -->