### PR TITLE
release(cli): rename npm package to salesforce-compound-engineering-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 * **Installation paths (DIV-58).** `install` now writes into the directory you run it from instead of back into the plugin, via a new `--output <dir>` flag. Passing a plugin *name* downloads the plugin from GitHub into `$XDG_CACHE_HOME/sfce/plugins` rather than resolving against the working directory, so the advertised one-line install works from any project. Tool auto-detection (`--to all`) now inspects the output directory.
 * **npm publish readiness.** `prepublishOnly` build, `publishConfig.access: public`, `engines`, repository `directory`, and a package README added to `cli/package.json` so the first publish succeeds.
-* **Package renamed to `@divings/sf-compound-plugin`.** The previously advertised `@divingsbysangam` scope does not exist on npm — scopes must match an npm username or an org you own — so publishing it returned `404 Scope not found`. The package now ships under the `@divings` org.
+* **Package renamed to `salesforce-compound-engineering-plugin`.** The name now matches the repository. Two earlier names did not survive contact with npm: `@divingsbysangam/sf-compound-plugin` named a scope that does not exist (scopes must match an npm username or an org you own, and `divingsbysangam` is the GitHub org), and `@divings/sf-compound-plugin` published successfully but scoped the package to an org name that says nothing about what it installs. The unscoped name is what `bunx` users will actually type.
+* **`@divings/sf-compound-plugin` is superseded** at `1.0.1`. It stays on the registry — npm does not remove published versions — and should be deprecated to point at the new name.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -60,11 +60,13 @@ converted files into your project:
 
 ```bash
 cd ~/code/my-salesforce-project
-bunx @divings/sf-compound-plugin install sf-compound-engineering --to cursor
+bunx salesforce-compound-engineering-plugin install sf-compound-engineering --to cursor
 ```
 
-No Bun? `npx -y @divings/sf-compound-plugin …` works identically — the CLI ships
-as a plain Node binary and needs only Node 18+.
+No Bun? `npx -y salesforce-compound-engineering-plugin …` works identically — the CLI ships
+as a plain Node binary and needs only Node 18+. Installed globally
+(`npm i -g salesforce-compound-engineering-plugin`), the same tool is available as the
+shorter `sf-compound-plugin`.
 
 Swap `--to cursor` for any target: `copilot`, `windsurf`, `gemini`, `opencode`,
 `codex`, `kiro`, `droid`, `pi`, `openclaw`, `qwen`, or `all` to install into
@@ -72,17 +74,17 @@ every tool detected in that project.
 
 ```bash
 # Install into every AI tool detected in this project
-bunx @divings/sf-compound-plugin install sf-compound-engineering --to all
+bunx salesforce-compound-engineering-plugin install sf-compound-engineering --to all
 
 # Install somewhere other than the current directory
-bunx @divings/sf-compound-plugin install sf-compound-engineering --to codex --output ~/code/other-project
+bunx salesforce-compound-engineering-plugin install sf-compound-engineering --to codex --output ~/code/other-project
 
 # Pin to a branch or tag instead of the default branch
 # (tags are listed at github.com/divingsbysangam/salesforce-compound-engineering-plugin/tags)
-bunx @divings/sf-compound-plugin install sf-compound-engineering --to cursor --ref v3.1.0-beta.3
+bunx salesforce-compound-engineering-plugin install sf-compound-engineering --to cursor --ref v3.1.0-beta.3
 
 # Reuse the cached copy without touching the network
-bunx @divings/sf-compound-plugin install sf-compound-engineering --to cursor --offline
+bunx salesforce-compound-engineering-plugin install sf-compound-engineering --to cursor --offline
 ```
 
 The downloaded plugin is cached under `$XDG_CACHE_HOME/sfce/plugins` (or
@@ -94,7 +96,7 @@ refresh fails, the cached copy is used rather than failing the install.
 ```bash
 git clone https://github.com/divingsbysangam/salesforce-compound-engineering-plugin
 cd ~/code/my-salesforce-project
-bunx @divings/sf-compound-plugin install ../salesforce-compound-engineering-plugin --to cursor
+bunx salesforce-compound-engineering-plugin install ../salesforce-compound-engineering-plugin --to cursor
 ```
 
 Contributors working inside a clone can use `sync`, which converts the plugin in place:
@@ -336,7 +338,7 @@ salesforce-compound-engineering-plugin/
 ├── PRINCIPLES.md             # Seven governing principles (source of truth)
 ├── CLAUDE.md                 # Project context and protected artifacts
 ├── cli/                      # Multi-tool installer CLI (Bun)
-│   ├── package.json          # @divings/sf-compound-plugin
+│   ├── package.json          # salesforce-compound-engineering-plugin
 │   ├── src/
 │   │   ├── index.ts          # CLI entry (citty)
 │   │   ├── parser/           # Plugin reader + markdown parser

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,4 +1,6 @@
-# @divings/sf-compound-plugin
+# salesforce-compound-engineering-plugin
+
+> Renamed from `@divings/sf-compound-plugin`, which is superseded at 1.0.1 and no longer updated.
 
 Installer for the [SF Compound Engineering Plugin](https://github.com/divingsbysangam/salesforce-compound-engineering-plugin) — Salesforce-aware compound engineering workflows for 11 AI coding tools that are not Claude Code.
 
@@ -11,10 +13,10 @@ Run it from the project you want the plugin installed into:
 
 ```bash
 cd ~/code/my-salesforce-project
-bunx @divings/sf-compound-plugin install sf-compound-engineering --to cursor
+bunx salesforce-compound-engineering-plugin install sf-compound-engineering --to cursor
 ```
 
-`npx -y @divings/sf-compound-plugin …` works the same way if you do not have Bun.
+`npx -y salesforce-compound-engineering-plugin …` works the same way if you do not have Bun.
 
 The plugin source is downloaded from GitHub on first run and cached under
 `$XDG_CACHE_HOME/sfce/plugins` (or `~/.cache/sfce/plugins`). Converted files are
@@ -39,9 +41,18 @@ output directory.
 ### Other commands
 
 ```bash
-bunx @divings/sf-compound-plugin sync            # re-run conversion in place
-bunx @divings/sf-compound-plugin lint            # check for dangling references
-bunx @divings/sf-compound-plugin feed list       # Tend runtime
+bunx salesforce-compound-engineering-plugin sync            # re-run conversion in place
+bunx salesforce-compound-engineering-plugin lint            # check for dangling references
+bunx salesforce-compound-engineering-plugin feed list       # Tend runtime
+```
+
+## Installed globally
+
+`npm i -g salesforce-compound-engineering-plugin` provides two identical commands —
+the full package name, and `sf-compound-plugin` as a shorter alias:
+
+```bash
+sf-compound-plugin install sf-compound-engineering --to cursor
 ```
 
 ## Requirements

--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "@divingsbysangam/sf-compound-plugin",
+      "name": "salesforce-compound-engineering-plugin",
       "dependencies": {
         "citty": "^0.1.6",
         "gray-matter": "^4.0.3",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "@divings/sf-compound-plugin",
+  "name": "salesforce-compound-engineering-plugin",
   "version": "1.0.1",
   "description": "Multi-tool installer for SF Compound Engineering Plugin — converts Claude Code plugins to Copilot, Windsurf, Gemini, Kiro, OpenCode, Codex",
   "type": "module",
   "bin": {
+    "salesforce-compound-engineering-plugin": "dist/index.js",
     "sf-compound-plugin": "dist/index.js"
   },
   "scripts": {

--- a/docs/install-verification.md
+++ b/docs/install-verification.md
@@ -173,7 +173,7 @@ install until `install` is re-run. Consider a `--copy` flag if this bites.
 
 ## Still outstanding
 
-- **Republish after every CLI change.** `1.0.0` was published mid-review and did not contain the destination-reporting fix, so for a window the registry served a binary that misreported where OpenClaw and Qwen install. Verify with `npm view @divings/sf-compound-plugin version` against `cli/package.json` before trusting a matrix row.
+- **Republish after every CLI change.** `1.0.0` was published mid-review and did not contain the destination-reporting fix, so for a window the registry served a binary that misreported where OpenClaw and Qwen install. Verify with `npm view salesforce-compound-engineering-plugin version` against `cli/package.json` before trusting a matrix row.
 - **Five converters are unverified in a clean environment**: OpenCode, Kiro, Pi, OpenClaw and Qwen. They have unit tests but no install run. Windsurf, Gemini and Droid were exercised through `--to all` in Round 1.
 - **Claude Code has had no fresh-user install run.** Manifests are valid and reachable; the install itself is unconfirmed, because `/plugin` cannot be driven from a shell.
 - **Tool-load is unconfirmed everywhere.** Every verified row proves files land in the right place, not that the tool reads them.


### PR DESCRIPTION
Follow-up to #9 and #10 (DIV-58). The package name now matches the repository.

`salesforce-compound-engineering-plugin` is confirmed available on npm (registry returns 404 for it today).

## Why a third name

| Name | Outcome |
|---|---|
| `@divingsbysangam/sf-compound-plugin` | **Never published.** Named a scope that does not exist — npm scopes must match a username or an org you own, and `divingsbysangam` is the *GitHub* org. Publishing returned `404 Scope not found`. |
| `@divings/sf-compound-plugin` | **Published, now superseded at 1.0.1.** Works, but scopes the package to an org name that says nothing about what it installs. |
| `salesforce-compound-engineering-plugin` | Matches the repository. What a reader would guess. |

## Changes

- **`cli/package.json`** — renamed; version stays **1.0.1** so both package names are verifiably the same code at the same number rather than implying a different build.
- **A second bin** named after the package, alongside the existing `sf-compound-plugin`.
- **README, cli/README, CHANGELOG, docs** — every live command updated (8 + 6 occurrences).

## On the second bin

`bunx <pkg>` and `npx <pkg>` resolve a bin matching the package name first, then fall back to running the sole bin when there is exactly one. The old single bin (`sf-compound-plugin`) would have relied on that fallback holding in both runtimes.

Given this issue exists because the README advertised commands nobody had run, depending on undocumented fallback behaviour for the headline one-liner seemed like the wrong trade. Shipping a bin named after the package removes the question. `sf-compound-plugin` stays as the short alias for global installs — both verified from a globally installed tarball:

```
$ ls prefix/bin
salesforce-compound-engineering-plugin
sf-compound-plugin
$ both --version → 1.0.1
```

Full install re-verified from the packed tarball into an empty project: 68 skills, correct destination.

Gates: typecheck clean · **79 tests pass / 0 fail** · plugin lint and Cursor validator pass.

## What history keeps

Changelog and verification-log entries that describe *what shipped at the time* keep their original names — same reasoning as leaving `docs/plans/` alone in #9. Only live guidance moved.

## After merge

```bash
cd cli && npm publish
npm deprecate @divings/sf-compound-plugin "renamed to salesforce-compound-engineering-plugin"
```

The old package cannot be removed — npm does not unpublish — so deprecating it is what stops people landing on a stale install path. I'll re-run the registry verification against the new name once it is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHcB3XDZjZaTtFFMWqzeMJ




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR renames the npm package to match the repository while preserving the existing short executable alias.
- Updates the manifest and lockfile to use `salesforce-compound-engineering-plugin`.
- Adds a package-name executable alongside `sf-compound-plugin`.
- Updates live installation guidance while retaining historical package names in release records.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the manifest and lockfile now consistently identify the renamed package.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| cli/package.json | Renames the package and maps both the full and short command names to the existing CLI entry point. |
| cli/bun.lock | Updates the workspace identity to match the renamed package manifest, resolving the prior review finding. |
| README.md | Updates current installation commands and documents the retained short global alias. |
| cli/README.md | Updates package-specific usage instructions and explains the superseded package and global command aliases. |
| CHANGELOG.md | Records the package rename and deprecation plan while preserving historical release information. |
| docs/install-verification.md | Adds verification details for the renamed package and both installed executable names. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(cli): update the stale workspace nam..."](https://github.com/divingsbysangam/salesforce-compound-engineering-plugin/commit/fb8729d1ade76eb001e70496d34e2c6c256d85cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55550080)</sub>

<!-- /greptile_comment -->