### PR TITLE
ci: fail main when the registry does not serve what the docs advertise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Pinned action SHAs are only safe if something keeps them current — an
+# unmaintained pin is a permanent freeze at whatever was released that day,
+# security fixes included. Dependabot proposes the bump; the SHA keeps the
+# change reviewable.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,14 +12,14 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
       - name: Validate Cursor plugin packaging

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -1,0 +1,37 @@
+name: Release check
+
+# Does the registry serve what this repo advertises?
+#
+# Blocking on `main`, where "merged but never published" is a live defect users
+# hit. Advisory on pull requests, where a version bump legitimately precedes the
+# publish it describes — failing there would punish the correct workflow.
+#
+# The daily run catches drift that no commit causes: a version deprecated, a
+# `latest` tag moved, a package unpublished within npm's 72-hour window.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "17 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  npm-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Check the registry against cli/package.json
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            node scripts/check-npm-release.mjs --warn-only
+          else
+            node scripts/check-npm-release.mjs
+          fi

--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -24,8 +24,8 @@ jobs:
   npm-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
       - name: Check the registry against cli/package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Added
 
 * `BaseConverter.installRoot()` — each converter declares where it actually writes, and `install` reports any destination outside the requested `--output` directory. Windsurf at global scope, OpenClaw and Qwen install user-globally because that is the only place those tools load from.
+* `scripts/check-npm-release.mjs` and a **Release check** workflow — fails a push to `main` when the npm registry does not serve the name and version `cli/package.json` declares, or when the READMEs advertise a different package than the manifest. Advisory on pull requests; runs daily.
 * `docs/install-verification.md` — clean-environment verification log behind the README install matrix.
 * README install matrix with prerequisites, last-verified date, known limitations, and owner per path.
 

--- a/scripts/check-npm-release.mjs
+++ b/scripts/check-npm-release.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Release check: does the registry actually serve what this repo advertises?
+ *
+ * DIV-58 hit the same gap three times — the package was never published, a fix
+ * was published before it was merged, and a rename landed in the repo while npm
+ * still 404'd the new name. Merging changes what the docs say; publishing
+ * changes what the docs describe. Nothing tied the two together, so this does.
+ *
+ * Two questions, both answerable without credentials:
+ *   1. Does the registry serve the name and version cli/package.json declares?
+ *   2. Do the install commands in the READMEs name that same package?
+ *
+ * Usage: node scripts/check-npm-release.mjs [--warn-only]
+ */
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const WARN_ONLY = process.argv.includes("--warn-only");
+
+const problems = [];
+const notes = [];
+
+const pkg = JSON.parse(readFileSync(join(ROOT, "cli", "package.json"), "utf-8"));
+const { name, version } = pkg;
+console.log(`Declared in cli/package.json: ${name}@${version}`);
+
+/** Fetch the registry document, retrying so a blip is not read as "unpublished". */
+async function fetchRegistry(pkgName) {
+  const url = `https://registry.npmjs.org/${pkgName.replace("/", "%2f")}`;
+  let lastError;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const res = await fetch(url, { headers: { accept: "application/json" } });
+      if (res.status === 404) return { missing: true };
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return { doc: await res.json() };
+    } catch (err) {
+      lastError = err;
+      if (attempt < 3) await new Promise((r) => setTimeout(r, attempt * 1000));
+    }
+  }
+  // A check that cannot reach the registry has not passed — it has not run.
+  throw new Error(`could not reach the npm registry after 3 attempts: ${lastError?.message}`);
+}
+
+const { missing, doc } = await fetchRegistry(name);
+
+if (missing) {
+  problems.push(
+    `${name} is not on the npm registry at all. Every documented ` +
+      `\`bunx ${name} …\` command 404s for users. Publish with \`cd cli && npm publish\`.`,
+  );
+} else {
+  const versions = Object.keys(doc.versions ?? {});
+  const latest = doc["dist-tags"]?.latest;
+
+  if (!versions.includes(version)) {
+    problems.push(
+      `main declares ${name}@${version}, but the registry's newest is ` +
+        `${latest ?? "none"} (published: ${versions.join(", ") || "none"}). ` +
+        `The merged code has not reached users — run \`cd cli && npm publish\`.`,
+    );
+  } else {
+    console.log(`Registry serves ${name}@${version}.`);
+    if (latest !== version) {
+      problems.push(
+        `${name}@${version} is published but \`latest\` points at ${latest}. ` +
+          `\`bunx ${name}\` installs ${latest}, not what this repo documents.`,
+      );
+    }
+    const deprecated = doc.versions[version]?.deprecated;
+    if (deprecated) {
+      problems.push(`${name}@${version} is deprecated on the registry: "${deprecated}"`);
+    }
+  }
+}
+
+// The second half of the gap: the manifest and the docs naming different
+// packages. Both were true at once during the DIV-58 rename.
+for (const rel of ["README.md", join("cli", "README.md")]) {
+  const text = readFileSync(join(ROOT, rel), "utf-8");
+  const advertised = new Set(
+    [...text.matchAll(/(?:bunx|npx)(?:\s+-y)?\s+((?:@[\w.-]+\/)?[\w.-]+)/g)].map((m) => m[1]),
+  );
+  advertised.delete("-y");
+  const wrong = [...advertised].filter((n) => n !== name);
+  if (advertised.size === 0) {
+    notes.push(`${rel}: no bunx/npx install command found to check.`);
+  } else if (wrong.length) {
+    problems.push(
+      `${rel} advertises ${wrong.map((w) => `\`${w}\``).join(", ")} but ` +
+        `cli/package.json declares \`${name}\`.`,
+    );
+  } else {
+    console.log(`${rel} advertises ${name}.`);
+  }
+}
+
+for (const note of notes) console.log(`Note: ${note}`);
+
+if (problems.length === 0) {
+  console.log("\nRelease check passed: the registry serves what this repo advertises.");
+  process.exit(0);
+}
+
+console.error(`\nRelease check found ${problems.length} problem(s):`);
+for (const p of problems) console.error(`  - ${p}`);
+process.exit(WARN_ONLY ? 0 : 1);


### PR DESCRIPTION
Follow-up to DIV-58. Implements the release check recommended in #12.

## Why

The same gap appeared three times in this issue, and each time the repository was correct while users were not:

| # | What was true on `main` | What users got |
|---|---|---|
| 1 | README advertised `bunx @divingsbysangam/…` | 404 — never published |
| 2 | Destination fix merged in #9 | 1.0.0 on npm, published before the fix |
| 3 | Rename merged in #11 | npm still 404'd the new name |

It is structural rather than careless. **Merging changes what the docs say; publishing changes what the docs describe.** Nothing tied them together.

## What it checks

`scripts/check-npm-release.mjs` asks two questions, neither needing credentials:

1. **Does the registry serve what `cli/package.json` declares?** Name exists, version present, tagged `latest`, and not deprecated.
2. **Do the READMEs advertise that same package?** The manifest and the docs named different packages for the whole length of the rename — this catches that directly.

Runnable locally the same way as `validate-cursor-plugin.mjs`:

```
$ node scripts/check-npm-release.mjs
Declared in cli/package.json: salesforce-compound-engineering-plugin@1.0.1
Registry serves salesforce-compound-engineering-plugin@1.0.1.
README.md advertises salesforce-compound-engineering-plugin.
cli/README.md advertises salesforce-compound-engineering-plugin.

Release check passed: the registry serves what this repo advertises.
```

## Trigger semantics

- **Blocking on `main`** — where "merged but never published" is a live defect users hit.
- **Advisory on pull requests** (`--warn-only`) — a version bump legitimately precedes the publish it describes, so failing there would punish the correct workflow.
- **Daily** — catches drift no commit causes: a version deprecated, `latest` moved, a package unpublished inside npm's 72-hour window.

## A deliberate choice about failure

An unreachable registry is reported as a **failure** after three retries, not a quiet pass. A check that cannot run has not passed, and a soft-failing check is one that silently stops checking — which is the failure mode this whole issue is about.

## Verified failure modes

Each exercised against live registry data, not mocks:

| Scenario | Detected |
|---|---|
| Version merged but not published | ✅ names the gap and the fix command |
| Package name absent from registry | ✅ plus both README mismatches |
| Manifest/README name disagreement | ✅ |
| Version deprecated | ✅ against the real `@divings/sf-compound-plugin@1.0.1` |
| Published but `latest` points elsewhere | ✅ against the real `@divings/sf-compound-plugin@1.0.0` |
| `--warn-only` | ✅ exits 0 while still printing problems |

Exit code is 1 on failure, 0 on pass.

## Note on ordering

#12 is still open and its Round 3 text recommends this check as future work. I've kept this PR self-contained rather than entangling the two; once both land I'll update that wording to describe the check as existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHcB3XDZjZaTtFFMWqzeMJ




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds an npm release-consistency check that blocks pushes to main, runs daily, and remains advisory on pull requests. The follow-up revision pins every GitHub Action reference to an immutable commit and configures Dependabot to propose weekly action updates.
- Validates the manifest package name, version, latest tag, and deprecation state against npm.
- Checks README bunx/npx package names against the CLI manifest.
- Adds scheduled, push, pull-request, and manually dispatched workflow triggers.
- Pins all workflow actions and adds automated maintenance for those pins.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported mutable action references are now pinned to full immutable commit SHAs.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/check-npm-release.mjs | Adds the registry and documentation consistency checks with retry handling and advisory-mode exit behavior. |
| .github/workflows/release-check.yml | Runs the checker for pushes, pull requests, schedules, and manual dispatches using immutable action references. |
| .github/workflows/quality.yml | Replaces all existing mutable GitHub Action tags with full commit SHAs. |
| .github/dependabot.yml | Configures weekly GitHub Actions update proposals to maintain pinned references. |
| CHANGELOG.md | Documents the release checker, its blocking and advisory behavior, and its daily schedule. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Workflow trigger] --> B[Checkout pinned commit]
  B --> C[Set up Node pinned commit]
  C --> D[Run npm release checker]
  D --> E[Read CLI manifest and READMEs]
  D --> F[Query npm registry]
  E --> G{Consistency checks pass?}
  F --> G
  G -->|Yes| H[Exit successfully]
  G -->|No, pull request| I[Report warnings and exit successfully]
  G -->|No, main or scheduled run| J[Report problems and fail]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["ci: pin workflow actions to immutable co..."](https://github.com/divingsbysangam/salesforce-compound-engineering-plugin/commit/a3ab0aace983dd70766c29f46bc369120318a621) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55554556)</sub>

<!-- /greptile_comment -->