### PR TITLE
chore(cli): update dependencies deferred from #11

### DIFF
--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -15,13 +15,13 @@
     },
   },
   "packages": {
-    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
-    "@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 
     "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
-    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
 
@@ -35,7 +35,7 @@
 
     "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
 
-    "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
+    "js-yaml": ["js-yaml@3.15.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag=="],
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
@@ -47,6 +47,6 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
   }
 }


### PR DESCRIPTION
The dependency bump held back during the rename in #11, now reviewable on its own.

Lockfile only — `cli/bun.lock`, no manifest changes.

| Package | From | To | Kind |
|---|---|---|---|
| `@types/bun` | 1.3.9 | 1.4.0 | dev |
| `@types/node` | 25.3.3 | 26.2.0 | dev, **major** |
| `bun-types` | 1.3.9 | 1.4.0 | dev |
| `undici-types` | 7.18.2 | 8.3.0 | dev, **major** |
| `js-yaml` | 3.14.2 | 3.15.1 | **runtime**, transitive via gray-matter |

## Why this wasn't in #11

Regenerating the lockfile for the rename would have swept these along with it. A dependency change inside a rename gets reviewed as a naming change — and one of these is a runtime dependency, not a type package.

## The one that carries risk

`js-yaml` is what gray-matter uses to parse **every skill's frontmatter** — including the `description` field that drives auto-routing on every platform. Type packages only have to satisfy `tsc`; this one changes what the product does if it changes at all.

So it's verified behaviourally, not just by the test suite. All 68 skills converted for Codex, Copilot, Gemini and Kiro, before and after:

```
before: 1722 files, checksum 736ad30e91cf0f3a614cfe66febd8f6683ba42c3
after:  1722 files, checksum 736ad30e91cf0f3a614cfe66febd8f6683ba42c3
diff -r before/ after/ → no output
```

Byte-identical across every converted file.

## Gates

- `tsc --noEmit` clean — `@types/node` crosses a major without errors
- **79 tests pass / 0 fail**
- `bun install --frozen-lockfile` (the form CI runs) accepts the regenerated lockfile
- build, plugin lint, Cursor validator, and the new release check all pass

## One thing left alone

`@types/bun` stays on `"latest"`. It looks like the cause of the lockfile drift we've been fighting, and pinning it to `^1.4.0` was tempting — but `"latest"` is Bun's own documented convention for that package, since it tracks the installed runtime. Deviating from upstream guidance to make our lockfile calmer seemed like the wrong trade. Happy to revisit if you'd rather have reproducibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHcB3XDZjZaTtFFMWqzeMJ
