### PR TITLE
docs: the release check exists, so stop describing it as future work

### DIFF
--- a/docs/install-verification.md
+++ b/docs/install-verification.md
@@ -159,14 +159,24 @@ Checks specific to this round:
 - **The 1.0.1 destination fix is in the published binary**, not just the repository. `--to openclaw` prints the real `~/.openclaw/extensions/…` destination and leaves the requested project empty, which is the corrected behaviour rather than the 1.0.0 defect.
 - **The deprecation fires.** Installing the old name emits `npm warn deprecated @divings/sf-compound-plugin@1.0.1: renamed to salesforce-compound-engineering-plugin`.
 
-### The recurring gap this round closes
+### The recurring gap, and what now closes it
 
 Three times in this issue a merge did not reach users: the package was never
 published, the destination fix was published-before-merge, and the rename landed
 in the repository while npm still 404'd the new name. Merging changes what the
-docs say; publishing changes what the docs describe. Nothing enforces the two
-happening together — worth a release check in CI that compares `cli/package.json`
-name and version against `npm view` on pushes to `main`.
+docs say; publishing changes what the docs describe, and nothing enforced the two
+happening together.
+
+`scripts/check-npm-release.mjs` now does, via the **Release check** workflow. It
+fails when the registry does not serve the name and version `cli/package.json`
+declares — missing, not tagged `latest`, or deprecated — or when the install
+commands in the READMEs name a different package than the manifest. It blocks on
+pushes to `main`, stays advisory on pull requests where a version bump correctly
+precedes its publish, and runs daily to catch drift no commit causes. Run it
+locally with `node scripts/check-npm-release.mjs`.
+
+An unreachable registry is reported as a failure after three retries rather than
+a quiet pass: a check that cannot run has not passed.
 
 ## Known caveats
 


### PR DESCRIPTION
One-line-ish docs follow-up, promised when #12 and #13 were split apart.

Round 3 of the verification log recommended a CI release check as future work. #13 built it. Left as written, the log tells a reader to go add a check the repo already runs on every push — the same species of stale-documentation problem DIV-58 exists to fix.

Replaces the recommendation with what actually shipped: what it checks, why it blocks on `main` but only warns on pull requests, and how to run it locally.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHcB3XDZjZaTtFFMWqzeMJ


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This documentation follow-up replaces a stale recommendation for a future release check with an accurate description of the check that now exists.
- Documents the registry, package metadata, and README consistency checks.
- Explains enforcement differences between `main` pushes and pull requests.
- Records the daily schedule, retry behavior, and local invocation.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the documentation accurately reflects the existing release-check implementation.

The referenced script and workflow exist, the documented validation conditions and retry behavior match the implementation, and the local command is correct.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/install-verification.md | Updates the verification log to describe the existing release-check script and workflow; the documented behavior aligns with the repository implementation. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: the release check exists, so stop ..."](https://github.com/divingsbysangam/salesforce-compound-engineering-plugin/commit/4cfd7fec6ea257fcbc26448f70ac73474d3126d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55559589)</sub>

<!-- /greptile_comment -->